### PR TITLE
:sparkles: allow throwing original errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@power-rent/try-catch",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A TypeScript utility for simplified async error handling with Sentry integration",
   "main": "dist/index.js",
   "module": "dist/esm/index.js",

--- a/src/nextjs/index.ts
+++ b/src/nextjs/index.ts
@@ -36,7 +36,30 @@ export class Try<T, TArgs extends readonly Record<string, any>[] = Record<string
   private config: TryConfig<TArgs[0]>;
   private result?: TryResult<T>;
   private state: 'pending' | 'executed';
+  private static ignoreErrorTypes: string[] = []
 
+  /**
+   * Creates a new Try instance for simplified async error handling.
+   * 
+   * @param fn The function to execute (can be sync or async)
+   * @param args Arguments to pass to the function
+   * 
+   * @example
+   * ```typescript
+   * // With async function
+   * const result = new Try(fetchUser, userId);
+   * 
+   * // With multiple arguments
+   * const result = new Try(updateUser, { id: 1, name: 'John' }, { validateOnly: true });
+   * 
+   * // Chain configuration methods
+   * const value = await new Try(apiCall, params)
+   *   .report('API call failed')
+   *   .breadcrumbs(['userId', 'action'])
+   *   .tag('component', 'user-service')
+   *   .unwrap();
+   * ```
+   */
   constructor(
     fn: (...args: TArgs) => T | Promise<T>,
     ...args: TArgs
@@ -48,7 +71,33 @@ export class Try<T, TArgs extends readonly Record<string, any>[] = Record<string
   }
 
   /**
-   * Create a new Try instance with updated configuration
+   * Configure error types that should be thrown through without being wrapped.
+   * When using `.report()`, errors matching these types will be re-thrown as-is
+   * instead of being wrapped with the custom message.
+   * 
+   * @param ignoreErrorTypes Array of error type names (error.name) to throw through
+   * 
+   * @example
+   * ```typescript
+   * // Configure to throw ValidationError and AuthError as-is
+   * Try.throwThroughErrorTypes(['ValidationError', 'AuthError']);
+   * 
+   * // Now these errors won't be wrapped:
+   * await new Try(validateUser, userData)
+   *   .report('User validation failed') // ValidationError will be thrown as-is
+   *   .unwrap();
+   * ```
+   */
+  public static throwThroughErrorTypes(ignoreErrorTypes: string[]) {
+    this.ignoreErrorTypes = ignoreErrorTypes;
+  }
+
+  /**
+   * Create a new Try instance with updated configuration.
+   * This method enables the fluent API by merging new configuration with existing settings.
+   * 
+   * @param newConfig Partial configuration to merge with existing config
+   * @returns The Try instance for method chaining
    */
   private setConfig(newConfig: Partial<TryConfig<TArgs[0]>>): Try<T, TArgs> {
     this.config = { ...this.config, ...newConfig };
@@ -56,22 +105,74 @@ export class Try<T, TArgs extends readonly Record<string, any>[] = Record<string
   }
 
   /**
-   * Attach a custom Sentry error message.
+   * Configure error reporting to Sentry with a custom message.
+   * When an error occurs and this method was called, the error will be captured
+   * by Sentry with the provided message and configured context.
+   * 
+   * @param message Custom error message to report to Sentry
+   * @returns The Try instance for method chaining
+   * 
+   * @example
+   * ```typescript
+   * // Basic error reporting
+   * await new Try(riskyOperation, data)
+   *   .report('Failed to process user data')
+   *   .unwrap();
+   * 
+   * // Combined with other configuration
+   * await new Try(apiCall, params)
+   *   .report('API call failed')
+   *   .tag('endpoint', '/users')
+   *   .breadcrumbs(['userId'])
+   *   .unwrap();
+   * ```
    */
   report(message: string): Try<T, TArgs> {
     return this.setConfig({ message });
   }
 
   /**
-   * Record breadcrumbs for the provided parameter keys.
-   * Only works when the first argument is an object – useful for most cases.
+   * Configure Sentry breadcrumbs to be extracted from the first function argument.
+   * Breadcrumbs provide additional context when errors are reported to Sentry.
+   * Only works when the first argument is an object.
+   * 
+   * @param keys Array of property keys from the first argument to include as breadcrumbs
+   * @returns The Try instance for method chaining
+   * 
+   * @example
+   * ```typescript
+   * // Extract userId and action as breadcrumbs
+   * await new Try(updateUser, { userId: 123, name: 'John', action: 'profile-update' })
+   *   .breadcrumbs(['userId', 'action'])
+   *   .report('User update failed')
+   *   .unwrap();
+   * 
+   * // Breadcrumbs will be added to Sentry context if an error occurs
+   * ```
    */
   breadcrumbs(keys: readonly (keyof TArgs[0])[]): Try<T, TArgs> {
     return this.setConfig({ breadcrumbKeys: keys });
   }
 
   /**
-   * Add a tag for Sentry error reporting.
+   * Add a custom tag for Sentry error reporting.
+   * Tags help categorize and filter errors in Sentry dashboards.
+   * Multiple tags can be added by calling this method multiple times.
+   * 
+   * @param name The tag name/key
+   * @param value The tag value
+   * @returns The Try instance for method chaining
+   * 
+   * @example
+   * ```typescript
+   * // Add multiple tags for better error categorization
+   * await new Try(processPayment, paymentData)
+   *   .tag('component', 'payment-service')
+   *   .tag('operation', 'charge-card')
+   *   .tag('gateway', 'stripe')
+   *   .report('Payment processing failed')
+   *   .unwrap();
+   * ```
    */
   tag(name: string, value: string): Try<T, TArgs> {
     return this.setConfig({
@@ -80,7 +181,26 @@ export class Try<T, TArgs extends readonly Record<string, any>[] = Record<string
   }
 
   /**
-   * Set default value
+   * Configure a default value to return when an error occurs.
+   * This default value will be returned by `.value()` method if the function execution fails.
+   * The `.unwrap()` method will still throw errors regardless of this setting.
+   * 
+   * @param defaultValue The value to return when an error occurs
+   * @returns The Try instance for method chaining
+   * 
+   * @example
+   * ```typescript
+   * // Return empty array if fetching users fails
+   * const users = await new Try(fetchUsers)
+   *   .default([])
+   *   .value(); // Returns [] if fetchUsers throws
+   * 
+   * // Return null if user lookup fails
+   * const user = await new Try(findUser, userId)
+   *   .default(null)
+   *   .report('User lookup failed')
+   *   .value(); // Returns null if findUser throws
+   * ```
    */
   default<Return>(defaultValue: Return): Try<T, TArgs> {
     return this.setConfig({ defaultValue });
@@ -88,6 +208,29 @@ export class Try<T, TArgs extends readonly Record<string, any>[] = Record<string
 
   /**
    * Execute the function and return the result, or throw if there was an error.
+   * This method will always throw on errors, regardless of default value configuration.
+   * If `.report()` was configured, errors will be reported to Sentry before throwing.
+   * 
+   * @returns The successful result of the function execution
+   * @throws The original error or a wrapped error with custom message (depending on configuration)
+   * 
+   * @example
+   * ```typescript
+   * // Basic usage - throws on error
+   * const result = await new Try(fetchUser, userId).unwrap();
+   * 
+   * // With error reporting - reports to Sentry then throws
+   * const result = await new Try(updateUser, userData)
+   *   .report('User update failed')
+   *   .unwrap();
+   * 
+   * // With custom message - throws Error with custom message instead of original
+   * try {
+   *   await new Try(riskyOperation).report('Operation failed').unwrap();
+   * } catch (error) {
+   *   console.log(error.message); // "Operation failed"
+   * }
+   * ```
    */
   async unwrap(): Promise<Awaited<T>> {
     const result = await this.execute();
@@ -100,9 +243,8 @@ export class Try<T, TArgs extends readonly Record<string, any>[] = Record<string
         await this.reportError(result.error);
       }
 
-
       // Throw a wrapped error with custom message when provided, otherwise re-throw original
-      if (this.config.message) {
+      if (this.config.message && !Try.ignoreErrorTypes.includes(result.error.name)) {
         throw new Error(this.config.message);
       }
       throw result.error;
@@ -113,6 +255,28 @@ export class Try<T, TArgs extends readonly Record<string, any>[] = Record<string
 
   /**
    * Execute the function and return the error if one occurred, or undefined if successful.
+   * This method never throws - it returns the error as a value instead.
+   * Errors are not reported to Sentry when using this method.
+   * 
+   * @returns The error if execution failed, undefined if successful
+   * 
+   * @example
+   * ```typescript
+   * // Check for errors without throwing
+   * const error = await new Try(riskyOperation, data).error();
+   * if (error) {
+   *   console.log('Operation failed:', error.message);
+   *   // Handle error gracefully
+   * }
+   * 
+   * // Conditional logic based on error type
+   * const error = await new Try(validateInput, userInput).error();
+   * if (error instanceof ValidationError) {
+   *   showValidationMessage(error.message);
+   * } else if (error) {
+   *   showGenericError();
+   * }
+   * ```
    */
   async error(): Promise<Error | undefined> {
     const result = await this.execute();
@@ -120,7 +284,32 @@ export class Try<T, TArgs extends readonly Record<string, any>[] = Record<string
   }
 
   /**
-   * Execute the function and return the value if successful, or undefined if there was an error.
+   * Execute the function and return the value if successful, or a default value/undefined if there was an error.
+   * This method never throws - it returns undefined (or configured default) on errors.
+   * If `.report()` was configured, errors will be reported to Sentry.
+   * If breadcrumbs were configured, they will be added to Sentry context.
+   * 
+   * @returns The successful result, configured default value, or undefined if execution failed
+   * 
+   * @example
+   * ```typescript
+   * // Basic usage - returns undefined on error
+   * const user = await new Try(fetchUser, userId).value();
+   * if (user) {
+   *   displayUser(user);
+   * }
+   * 
+   * // With default value - returns default on error
+   * const users = await new Try(fetchUsers)
+   *   .default([])
+   *   .value(); // Returns [] if fetchUsers fails
+   * 
+   * // With error reporting - reports to Sentry but still returns undefined
+   * const result = await new Try(criticalOperation)
+   *   .report('Critical operation failed')
+   *   .breadcrumbs(['operationId'])
+   *   .value(); // undefined if failed, but error is reported to Sentry
+   * ```
    */
   async value(): Promise<Awaited<T> | undefined> {
     const result = await this.execute();
@@ -145,6 +334,10 @@ export class Try<T, TArgs extends readonly Record<string, any>[] = Record<string
 
   /**
    * Execute the function and return a result object with success status, value, and error.
+   * This is the core execution method that handles both sync and async functions.
+   * Results are cached after first execution to avoid re-running the function.
+   * 
+   * @returns Promise resolving to a result object indicating success/failure
    */
   private async execute(): Promise<TryResult<T>> {
     if (this.state === 'executed' && this.result) {
@@ -215,9 +408,28 @@ export class Try<T, TArgs extends readonly Record<string, any>[] = Record<string
   }
 
   /**
-   * Make the Try instance thenable so it can be `await`-ed directly. This executes
-   * the underlying function with the current configuration and resolves with the
-   * same result as calling `.value()`.
+   * Make the Try instance thenable so it can be `await`-ed directly.
+   * This executes the underlying function with the current configuration and resolves
+   * with the same result as calling `.value()` (never throws, returns undefined on error).
+   * 
+   * @param onfulfilled Callback for successful resolution
+   * @param onrejected Callback for rejection (rarely used since this doesn't reject)
+   * @returns Promise that resolves with the result or undefined
+   * 
+   * @example
+   * ```typescript
+   * // Direct await - equivalent to .value()
+   * const user = await new Try(fetchUser, userId)
+   *   .report('Failed to fetch user');
+   * 
+   * // Can be used in Promise chains
+   * const result = await new Try(processData, input)
+   *   .default('fallback')
+   *   .then(data => data?.toUpperCase() || 'NO DATA');
+   * 
+   * // Behaves like .value() - never throws
+   * const users = await new Try(fetchUsers); // undefined if error
+   * ```
    */
   then<TResult1 = Awaited<T> | undefined, TResult2 = never>(
     onfulfilled?: ((value: Awaited<T> | undefined) => TResult1 | PromiseLike<TResult1>) | undefined | null,


### PR DESCRIPTION
This PR introduces the ability to throw original errors instead of wrapped errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to configure specific error types to bypass error wrapping and be rethrown directly.
- **Documentation**
  - Enhanced and expanded usage documentation for all public methods, including detailed examples and behavior explanations.
- **Tests**
  - Added and updated tests to verify new error handling behavior and ensure correct functionality.
- **Chores**
  - Updated the package version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->