### PR TITLE
add finally

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ const user = await new Try(fetchUser, userId)
   .report('Failed to fetch user')
   .breadcrumbs(['userId'])
   .default(null)
+  .finally(() => {
+    console.log('Completed fetching user')
+  })
   .value();
 
 // Pattern 2: Check errors explicitly

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@power-rent/try-catch",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "A TypeScript utility for simplified async error handling with Sentry integration",
   "main": "dist/index.js",
   "module": "dist/esm/index.js",

--- a/src/__tests__/Try.test.ts
+++ b/src/__tests__/Try.test.ts
@@ -228,4 +228,26 @@ describe('Try', () => {
     expect(() => result.ok).not.toThrow(TypeError);
     expect(Sentry.captureException).not.toHaveBeenCalled();
   });
+
+  it('should execute finally callback on success', async () => {
+    const params = { parameterKey: 'alpha' };
+    const finallySpy = vi.fn();
+
+    await new Try(successfulFunction, params)
+      .finally(finallySpy)
+      .unwrap();
+
+    expect(finallySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should execute finally callback on error', async () => {
+    const params = { parameterKey: 'alpha' };
+    const finallySpy = vi.fn();
+
+    await new Try(throwingFunction, params)
+      .finally(finallySpy)
+      .value();
+
+    expect(finallySpy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/__tests__/Try.test.ts
+++ b/src/__tests__/Try.test.ts
@@ -244,10 +244,10 @@ describe('Try', () => {
     const params = { parameterKey: 'alpha' };
     const finallySpy = vi.fn();
 
-    await new Try(throwingFunction, params)
+    const exec = new Try(throwingFunction, params)
       .finally(finallySpy)
-      .value();
-
+      .unwrap();
+    await expect(exec).rejects.toThrow('boom');
     expect(finallySpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/nextjs/index.ts
+++ b/src/nextjs/index.ts
@@ -42,8 +42,6 @@ export class Try<T, TArgs extends readonly Record<string, any>[] = Record<string
   private result?: TryResult<T>;
   private state: 'pending' | 'executed';
   private static ignoreErrorTypes: string[] = []
-  /** Tracks whether the user supplied `finally` callback has already been executed */
-  private finallyExecuted = false;
 
   /**
    * Creates a new Try instance for simplified async error handling.


### PR DESCRIPTION
- **:sparkles: add finally callback to Try class**
- **:bookmark: bump version to 0.0.7**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for registering a callback to be executed after an operation completes, regardless of success or failure, similar to `Promise.prototype.finally`.
  * Introduced a new method to enable this functionality through the public API.

* **Documentation**
  * Updated the README example to demonstrate usage of the new `.finally()` method.

* **Tests**
  * Added tests to verify that the new callback is executed after both successful and failed operations.

* **Chores**
  * Incremented the package version to 0.0.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->