### PR TITLE
chore: CONTRIBUTING, husky pre-commit, and @sentry/* peer deps

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx lint-staged

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,8 +89,8 @@ A changeset is a file that describes what changes you've made and what type of v
    - Select which packages to include (this project has one package: `@power-rent/try-catch`)
    - Choose the version bump type:
      - **Major**: Breaking changes that require users to update their code
-     - **Minor**: New features that are backward compatible
-     - **Patch**: Bug fixes that are backward compatible
+     - **Minor**: New features that are backward-compatible
+     - **Patch**: Bug fixes that are backward-compatible
    - Write a description of your changes
 
 3. **The command will create a file** in the `.changeset/` directory with a random name like `cool-cats-sing.md`
@@ -264,8 +264,8 @@ npx changeset publish
 This project follows [Semantic Versioning](https://semver.org/):
 
 - **MAJOR** (1.0.0 → 2.0.0): Breaking changes
-- **MINOR** (1.0.0 → 1.1.0): New features, backward compatible
-- **PATCH** (1.0.0 → 1.0.1): Bug fixes, backward compatible
+- **MINOR** (1.0.0 → 1.1.0): New features, backward-compatible
+- **PATCH** (1.0.0 → 1.0.1): Bug fixes, backward-compatible
 
 ### Version Bump Guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,447 @@
+# Contributing to @power-rent/try-catch
+
+Thank you for your interest in contributing to the try-catch library! This guide will help you understand the development workflow, including how to make changes, manage versions, and create changelogs.
+
+## Table of Contents
+
+- [Development Setup](#development-setup)
+- [Making Changes](#making-changes)
+- [Changelog Creation Process](#changelog-creation-process)
+- [Release Process](#release-process)
+- [Version Management](#version-management)
+- [Testing](#testing)
+- [Code Style](#code-style)
+- [Pull Request Process](#pull-request-process)
+
+## Development Setup
+
+### Prerequisites
+
+- Node.js >= 20
+- npm (comes with Node.js)
+- Git
+
+### Installation
+
+```bash
+# Clone the repository
+git clone https://github.com/Toprent-app/try-catch.git
+cd try-catch
+
+# Install dependencies
+npm install
+
+# Build the project
+npm run build
+
+# Run tests
+npm test
+```
+
+### Available Scripts
+
+```bash
+npm run build          # Build both CommonJS and ESM versions
+npm run build:cjs      # Build CommonJS version only
+npm run build:esm      # Build ESM version only
+npm run test           # Run tests once
+npm run test:watch     # Run tests in watch mode
+npm run format         # Format code with Prettier
+npm run format:check   # Check code formatting
+npm run typecheck      # Run TypeScript type checking
+npm run clean          # Clean build artifacts
+```
+
+## Making Changes
+
+### 1. Create a Feature Branch
+
+```bash
+git checkout -b feature/your-feature-name
+```
+
+### 2. Make Your Changes
+
+- Write your code following the existing patterns
+- Add tests for new functionality
+- Update documentation if needed
+- Ensure all tests pass: `npm test`
+
+### 3. Create a Changeset
+
+This project uses [Changesets](https://github.com/changesets/changesets) for version management and changelog generation.
+
+#### What is a Changeset?
+
+A changeset is a file that describes what changes you've made and what type of version bump they require. This information is used to:
+- Automatically generate changelogs
+- Determine version bumps (major, minor, patch)
+- Create release pull requests
+
+#### Creating a Changeset
+
+1. **Run the changeset command:**
+   ```bash
+   npx changeset
+   ```
+
+2. **Follow the interactive prompts:**
+   - Select which packages to include (this project has one package: `@power-rent/try-catch`)
+   - Choose the version bump type:
+     - **Major**: Breaking changes that require users to update their code
+     - **Minor**: New features that are backward compatible
+     - **Patch**: Bug fixes that are backward compatible
+   - Write a description of your changes
+
+3. **The command will create a file** in the `.changeset/` directory with a random name like `cool-cats-sing.md`
+
+#### Manual Changeset Creation
+
+You can also create changeset files manually:
+
+1. **Create a new file** in the `.changeset/` directory with a descriptive name:
+   ```bash
+   touch .changeset/your-descriptive-name.md
+   ```
+
+2. **Add the changeset content:**
+   ```markdown
+   ---
+   '@power-rent/try-catch': minor
+   ---
+
+   Add new breadcrumb extraction feature for better Sentry integration
+   ```
+
+#### Changeset File Format
+
+```markdown
+---
+'@power-rent/try-catch': major|minor|patch
+---
+
+Description of your changes. This will appear in the changelog.
+```
+
+**Examples:**
+
+```markdown
+---
+'@power-rent/try-catch': major
+---
+
+BREAKING: Remove deprecated error reporter class and update API
+```
+
+```markdown
+---
+'@power-rent/try-catch': minor
+---
+
+Add support for custom breadcrumb transformers
+```
+
+```markdown
+---
+'@power-rent/try-catch': patch
+---
+
+Fix memory leak in error reporting
+```
+
+### 4. Commit Your Changes
+
+```bash
+git add .
+git commit -m "feat: add new breadcrumb extraction feature
+
+- Add support for custom transformers
+- Improve TypeScript types
+- Add comprehensive tests"
+```
+
+**Commit Message Format:**
+- Use conventional commits format: `type(scope): description`
+- Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
+- Include the changeset file in your commit
+
+### 5. Push and Create Pull Request
+
+```bash
+git push origin feature/your-feature-name
+```
+
+Then create a pull request on GitHub.
+
+## Changelog Creation Process
+
+The changelog is automatically generated using Changesets. Here's how it works:
+
+### Automatic Process
+
+1. **Changeset Creation**: When you create a changeset file, it describes your changes
+2. **Release PR Generation**: GitHub Actions automatically creates a "Version Packages" PR when changesets exist
+3. **Changelog Generation**: When the release PR is merged, the changelog is automatically updated
+4. **Package Publishing**: The package is automatically published to npm
+
+### Manual Changelog Preview
+
+You can preview what the changelog will look like:
+
+```bash
+# See what changesets exist
+npx changeset status
+
+# Preview the release plan
+npx changeset version --dry-run
+```
+
+### Changelog Structure
+
+The generated `CHANGELOG.md` follows this format:
+
+```markdown
+# @power-rent/try-catch
+
+## 1.1.0
+
+### Minor Changes
+
+- a1b2c3d: Add support for custom breadcrumb transformers
+
+## 1.0.0
+
+### Major Changes
+
+- e4f5g6h: BREAKING: Remove deprecated error reporter class
+
+### Minor Changes
+
+- i7j8k9l: Improved developer experience and documentation
+```
+
+## Release Process
+
+### Automated Release via GitHub Actions
+
+The project uses GitHub Actions for automated releases:
+
+1. **Trigger**: Push to `main` branch
+2. **Workflow**: `.github/workflows/release.yml`
+3. **Action**: `changesets/action@v1`
+
+#### What Happens:
+
+1. **Build**: Installs dependencies and builds the project
+2. **Check for Changesets**: Looks for changeset files
+3. **Create Release PR**: If changesets exist, creates a "Version Packages" PR
+4. **Publish**: If release PR is merged, publishes to npm and updates changelog
+
+#### Release PR Process:
+
+1. GitHub Actions creates a PR titled "Version Packages"
+2. The PR includes:
+   - Updated `package.json` version
+   - Updated `CHANGELOG.md`
+   - Removed changeset files
+3. Review and merge the PR
+4. The package is automatically published to npm
+
+### Manual Release (if needed)
+
+```bash
+# Create release PR manually
+npx changeset version
+
+# Publish (requires npm login)
+npx changeset publish
+```
+
+## Version Management
+
+### Semantic Versioning
+
+This project follows [Semantic Versioning](https://semver.org/):
+
+- **MAJOR** (1.0.0 → 2.0.0): Breaking changes
+- **MINOR** (1.0.0 → 1.1.0): New features, backward compatible
+- **PATCH** (1.0.0 → 1.0.1): Bug fixes, backward compatible
+
+### Version Bump Guidelines
+
+**Major (Breaking Changes):**
+- Removing public APIs
+- Changing function signatures
+- Changing behavior in a way that breaks existing code
+- Removing deprecated features
+
+**Minor (New Features):**
+- Adding new methods or properties
+- Adding new functionality
+- Improving existing features without breaking changes
+
+**Patch (Bug Fixes):**
+- Fixing bugs
+- Improving performance
+- Updating documentation
+- Internal refactoring
+
+## Testing
+
+### Running Tests
+
+```bash
+# Run all tests
+npm test
+
+# Run tests in watch mode
+npm run test:watch
+
+# Run tests with coverage
+npm run test -- --coverage
+```
+
+### Writing Tests
+
+- Tests are located in `src/__tests__/`
+- Use Vitest as the testing framework
+- Follow the existing test patterns
+- Test both success and error cases
+- Include edge cases and type safety tests
+
+### Test Structure
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { Try } from '../Try';
+
+describe('Try class', () => {
+  it('should handle successful operations', async () => {
+    const result = await new Try(() => 'success').value();
+    expect(result).toBe('success');
+  });
+
+  it('should handle errors gracefully', async () => {
+    const error = await new Try(() => {
+      throw new Error('test error');
+    }).error();
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error?.message).toBe('test error');
+  });
+});
+```
+
+## Code Style
+
+### Formatting
+
+This project uses Prettier for code formatting:
+
+```bash
+# Format all files
+npm run format
+
+# Check formatting
+npm run format:check
+```
+
+### TypeScript
+
+- Use strict TypeScript settings
+- Provide proper type annotations
+- Use generic types where appropriate
+- Follow the existing type patterns
+
+### Code Organization
+
+- Keep functions small and focused
+- Use descriptive names
+- Add JSDoc comments for public APIs
+- Follow the existing file structure
+
+## Pull Request Process
+
+### Before Submitting
+
+1. **Ensure tests pass**: `npm test`
+2. **Check formatting**: `npm run format:check`
+3. **Type check**: `npm run typecheck`
+4. **Build successfully**: `npm run build`
+5. **Include changeset**: Make sure you've created a changeset file
+
+### PR Description Template
+
+```markdown
+## Description
+Brief description of changes
+
+## Type of Change
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+
+## Changeset
+- [ ] I have created a changeset for this PR
+
+## Testing
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] All tests pass locally
+
+## Checklist
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+```
+
+### Review Process
+
+1. **Automated Checks**: CI will run tests, type checking, and formatting
+2. **Code Review**: Maintainers will review your code
+3. **Changeset Review**: Ensure the changeset accurately describes your changes
+4. **Merge**: Once approved, the PR will be merged
+5. **Release**: GitHub Actions will create a release PR if changesets exist
+
+## Getting Help
+
+- **Issues**: Create an issue for bugs or feature requests
+- **Discussions**: Use GitHub Discussions for questions
+- **Documentation**: Check the README and examples for usage patterns
+
+## Development Tips
+
+### Local Development
+
+```bash
+# Watch mode for development
+npm run test:watch
+
+# Build in watch mode (if using a build tool that supports it)
+npm run build -- --watch
+```
+
+### Debugging
+
+```bash
+# Enable debug logging in your code
+const result = await new Try(riskyFunction, params)
+  .debug(true)  // Enable debug logging
+  .report('Function failed')
+  .value();
+```
+
+### Performance Testing
+
+```bash
+# Run performance tests
+npm test -- --reporter=verbose
+```
+
+## Release History
+
+The project uses automated releases. Check the [CHANGELOG.md](./CHANGELOG.md) for a complete history of changes.
+
+---
+
+Thank you for contributing to @power-rent/try-catch! 🚀

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,8 @@
         "@sentry/nextjs": ">=8.0.0 <11.0.0",
         "@sentry/node": ">=8.0.0 <11.0.0",
         "@types/node": "^20.19.1",
+        "husky": "^9.1.7",
+        "lint-staged": "^16.1.6",
         "prettier": "^3.6.2",
         "tsup": "^8.5.0",
         "type-fest": "^5.1.0",
@@ -22,6 +24,22 @@
       },
       "engines": {
         "node": ">=20"
+      },
+      "peerDependencies": {
+        "@sentry/browser": ">=8.0.0 <11.0.0",
+        "@sentry/nextjs": ">=8.0.0 <11.0.0",
+        "@sentry/node": ">=8.0.0 <11.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@sentry/browser": {
+          "optional": true
+        },
+        "@sentry/nextjs": {
+          "optional": true
+        },
+        "@sentry/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4463,6 +4481,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -4782,6 +4816,39 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -4807,6 +4874,13 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true,
       "license": "MIT"
     },
@@ -4944,6 +5018,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.18.3",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.3.tgz",
@@ -4971,6 +5052,19 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/es-module-lexer": {
@@ -5107,6 +5201,13 @@
       "dependencies": {
         "@types/estree": "^1.0.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -5330,6 +5431,19 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/glob": {
       "version": "9.3.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
@@ -5455,6 +5569,22 @@
         "human-id": "dist/cli.js"
       }
     },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
@@ -5532,6 +5662,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-glob": {
@@ -5742,6 +5888,68 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lint-staged": {
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz",
+      "integrity": "sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^14.0.3",
+        "listr2": "^9.0.5",
+        "picomatch": "^4.0.3",
+        "string-argv": "^0.3.2",
+        "tinyexec": "^1.0.4",
+        "yaml": "^2.8.2"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=20.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/lint-staged/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/lint-staged/node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
+      "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^5.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/load-tsconfig": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
@@ -5785,6 +5993,85 @@
       "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -5874,6 +6161,19 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimatch": {
@@ -6122,6 +6422,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/outdent": {
@@ -6702,6 +7018,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -6712,6 +7045,13 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.44.0",
@@ -6966,6 +7306,36 @@
         "node": ">=8"
       }
     },
+    "node_modules/slice-ansi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -7054,6 +7424,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/string-width-cjs": {
       "name": "string-width",
       "version": "4.2.3",
@@ -7085,6 +7482,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/strip-ansi": {
@@ -8486,6 +8912,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrap-ansi-cjs": {
       "name": "wrap-ansi",
       "version": "7.0.0",
@@ -8537,6 +8981,66 @@
         "node": ">=8"
       }
     },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -8553,6 +9057,22 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "test:watch": "vitest",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "npm run clean && npm run test && npm run build"
+    "prepublishOnly": "npm run clean && npm run test && npm run build",
+    "prepare": "husky install"
   },
   "keywords": [
     "typescript",
@@ -73,12 +74,30 @@
     "url": "https://github.com/Toprent-app/try-catch/issues"
   },
   "homepage": "https://github.com/Toprent-app/try-catch#readme",
+  "peerDependencies": {
+    "@sentry/browser": ">=8.0.0 <11.0.0",
+    "@sentry/nextjs": ">=8.0.0 <11.0.0",
+    "@sentry/node": ">=8.0.0 <11.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@sentry/nextjs": {
+      "optional": true
+    },
+    "@sentry/node": {
+      "optional": true
+    },
+    "@sentry/browser": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@changesets/cli": "^2.29.7",
     "@sentry/browser": ">=8.0.0 <11.0.0",
     "@sentry/nextjs": ">=8.0.0 <11.0.0",
     "@sentry/node": ">=8.0.0 <11.0.0",
     "@types/node": "^20.19.1",
+    "husky": "^9.1.7",
+    "lint-staged": "^16.1.6",
     "prettier": "^3.6.2",
     "tsup": "^8.5.0",
     "type-fest": "^5.1.0",
@@ -87,6 +106,11 @@
   },
   "engines": {
     "node": ">=20"
+  },
+  "lint-staged": {
+    "*.{ts,tsx,js,jsx,json}": [
+      "prettier --write"
+    ]
   },
   "typesVersions": {
     "*": {

--- a/src/__tests__/Try.test.ts
+++ b/src/__tests__/Try.test.ts
@@ -18,7 +18,7 @@ class GraphQLError extends Error {
 }
 
 class TestClass {
-  private name: string;
+  private readonly name: string;
 
   constructor(name: string) {
     this.name = name;


### PR DESCRIPTION
Rebased onto current `main`. The original breadcrumbs/type-fest fix already landed in `main` independently, so this PR now carries only the still-relevant parts:

- Add `@sentry/*` as optional **peerDependencies** (were devDeps only)
- Add **husky + lint-staged** pre-commit `prettier --write`
- Add **CONTRIBUTING.md**
- Mark `TestClass.name` readonly (test)
- Dropped the stale changeset describing the already-shipped fix

**Verification:** `typecheck` ✅, `vitest run` ✅ (416 tests).

**Note:** `npm run build` is currently broken on `main` too (main upgraded `typescript` to `^7.0.0`, incompatible with `rollup-plugin-dts@6.1.1`). Not addressed here — separate fix. Build isn't in CI, so it doesn't gate this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive contribution guide covering setup, testing, coding standards, pull requests, versioning, and release workflows.
* **Chores**
  * Added a `prepare` script to initialize commit hooks and integrated file-format linting for staged changes.
  * Enabled a pre-commit hook to automatically run staged linting and block commits on failures.
* **Tests**
  * Strengthened test reliability by making internal test metadata immutable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->