### PR TITLE
fix: breadcrumbs drop undefined positional values

### DIFF
--- a/.changeset/md-02-extract-from-array-undefined.md
+++ b/.changeset/md-02-extract-from-array-undefined.md
@@ -1,0 +1,5 @@
+---
+'@power-rent/try-catch': patch
+---
+
+Fix MD-02: positional string entries in `.breadcrumbs([...])` now drop arguments whose value is `undefined`, matching the semantics of `extractFromKeys` for object-key extraction.

--- a/src/__tests__/flexible-breadcrumbs.test.ts
+++ b/src/__tests__/flexible-breadcrumbs.test.ts
@@ -510,6 +510,33 @@ describe('Flexible Breadcrumbs System', () => {
       );
     });
 
+    it('positional string handler drops undefined values', async () => {
+      function testFunction(a?: string, b?: number, c?: boolean) {
+        throw new Error('test');
+      }
+
+      // Mix positional strings with an extractor so config exercises
+      // extractFromArray's positional-string branch (not extractFromKeys).
+      await new Try(testFunction, 'defined', undefined, true)
+        .breadcrumbs([
+          'a',
+          'b',
+          { param: 2, as: 'value' },
+        ])
+        .value();
+
+      expect(Sentry.addBreadcrumb).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Calling testFunction function',
+          data: {
+            a: 'defined',
+            param2_value: true,
+            // b should be filtered out (undefined positional value)
+          },
+        }),
+      );
+    });
+
     it('should work with functions that have no parameters', async () => {
       function noParams() {
         throw new Error('test');

--- a/src/utils/breadcrumbs.ts
+++ b/src/utils/breadcrumbs.ts
@@ -169,8 +169,11 @@ export class BreadcrumbExtractorUtil {
       // Positional syntax handling
       const arg = args[index];
       if (typeof entry === 'string') {
-        // Map value directly under the provided key
-        breadcrumbData = { ...breadcrumbData, [entry]: arg };
+        // Map value directly under the provided key; drop undefined
+        // to match `extractFromKeys` semantics.
+        if (arg !== undefined) {
+          breadcrumbData = { ...breadcrumbData, [entry]: arg };
+        }
       } else if (Array.isArray(entry)) {
         // Extract listed keys from an object argument
         if (arg && typeof arg === 'object') {


### PR DESCRIPTION
`.breadcrumbs([...])` positional string entries drop arguments whose value is `undefined`, matching `extractFromKeys` semantics for object-key extraction.

Standalone patch — independent of the stack below.

Part of the #36 split (1/3).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Breadcrumb data now omits positional fields whose values are `undefined`.
  * Retained values and extracted fields continue to appear correctly in Sentry breadcrumb payloads.

* **Documentation**
  * Added a patch release note describing the breadcrumb extraction fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->