### PR TITLE
docs: rewrite docs/examples + runnable doctest harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,42 +14,33 @@ This library lets you write what you mean, almost like English:
   - **get the error as a value** with `.error()`
   - **or let it throw** with `.unwrap()`
 
+New to the library? Read the next three sections in order — they're a
+newcomer-first tour. The [API reference](#api) lives at the bottom once the
+shape is familiar.
+
 Examples that read like a sentence:
 
-```ts
-// Try to get a user; if it fails, report and return null
-const user = await new Try(fetchUser, { id: 123 })
-  .report('Failed to fetch user')
-  .default(null)
+```ts doctest
+import { Try } from '@power-rent/try-catch';
+
+// Try to parse JSON; if it fails, fall back to a default
+const value = await new Try(JSON.parse, '{"ok":true}')
+  .default({ ok: false })
   .value();
 
-// Try to charge a card; if it fails, throw with a custom message (and report)
-const receipt = await new Try(chargeCard, { amount: 1000, currency: 'USD' })
-  .report('Payment failed')
-  .unwrap();
+if ((value as { ok: boolean }).ok !== true) {
+  throw new Error(`expected ok:true, got ${JSON.stringify(value)}`);
+}
+```
+
+```ts doctest
+import { Try } from '@power-rent/try-catch';
 
 // Try to parse JSON; if it fails, give me the error instead of throwing
-const error = await new Try(JSON.parse, raw)
-  .error();
-
-// Or try to parse JSON; if it fails, give me the default value instead of throwing
-const value = await new Try(JSON.parse, raw)
-  .default({ initial: 'value' })
-  .value();
-
-// Or try to parse JSON; if it fails, give me value or undefined instead of throwing
-const value = await new Try(JSON.parse, raw)
-  .value();
-
-// Try with flexible logic, the function will be executed once
-const shouldThrow = someCustomLogic();
-const attempt = await new Try(chargeCard, { amount: 1000, currency: 'USD' })
-const result = attempt.value();
-const error = attempt.error();
-if (shouldThrow) {
-  throw error;
+const error = new Try(JSON.parse, 'not-json').error();
+if (!(error instanceof Error)) {
+  throw new Error('expected an Error from .error() on bad JSON');
 }
-return result;
 ```
 
 ## Installation
@@ -58,21 +49,107 @@ return result;
 npm install @power-rent/try-catch
 ```
 
+Pick the entry point that matches your runtime. Each environment-specific
+entry auto-registers the right Sentry reporter as a side effect on import:
+
+```typescript
+// Node.js
+import { Try } from '@power-rent/try-catch/node';
+// Browser / bundler
+import { Try } from '@power-rent/try-catch/browser';
+// Next.js
+import { Try } from '@power-rent/try-catch/nextjs';
+// No Sentry — NoopReporter is active; supply your own reporter if you want one
+import { Try } from '@power-rent/try-catch';
+```
+
+## Sync vs Async
+
+`Try` instances are never thenable. Whether the wrapped function is sync or async, you must call a terminal method (`.value()`, `.unwrap()`, `.error()`, or `.result()`) to run it and read the outcome.
+
+**Async functions** — `await` the terminal method:
+
+```ts doctest
+import { Try } from '@power-rent/try-catch';
+
+async function asyncFn(arg: number) {
+  return arg * 2;
+}
+
+const result = await new Try(asyncFn, 21).value();
+
+if (result !== 42) {
+  throw new Error(`expected 42, got ${String(result)}`);
+}
+```
+
+**Sync functions (and sync fns returning a Promise)** — call a terminal method:
+
+```ts doctest
+import { Try } from '@power-rent/try-catch';
+
+const rawString = '{"ok":true}';
+
+// Sync function: call terminal method without await
+const result = new Try(JSON.parse, rawString).value();
+
+// Sync fn that returns a Promise: terminal methods still handle it.
+function returnsPromise(): Promise<number> {
+  return Promise.resolve(42);
+}
+const n = await new Try(returnsPromise).value();
+
+// Awaiting a Try instance directly yields the Try instance, NOT the result.
+// The instance is not thenable, so `await` cannot trigger execution.
+// Use .value() / .unwrap() / .error() / .result() instead.
+if ((result as { ok: boolean }).ok !== true || n !== 42) {
+  throw new Error('sync .value() path failed');
+}
+```
+
+If you are unsure whether a function is async, using `.value()` without `await` is always safe for sync functions, and using `await .value()` is always safe for async functions.
+
+## When your function throws something that isn't an `Error`
+
+Plenty of code throws strings, numbers, or bare objects. The library
+normalizes anything that isn't an `Error` into one: the wrapped error carries
+`message === 'Non-Error thrown (<type>)'` and preserves the original value on
+`.cause`. You never have to guess what `catch (e: unknown)` gave you.
+
+```ts doctest
+import { Try } from '@power-rent/try-catch';
+
+function misbehaves(): number {
+  throw 'boom';
+}
+
+const error = new Try(misbehaves).error();
+if (!(error instanceof Error)) {
+  throw new Error('expected an Error');
+}
+if (error.message !== 'Non-Error thrown (string)') {
+  throw new Error(`unexpected message: ${error.message}`);
+}
+if (error.cause !== 'boom') {
+  throw new Error(`cause not preserved, got ${String(error.cause)}`);
+}
+```
+
 ## Usage
 
-The `Try` class provides a fluent interface for handling async operations with automatic error reporting to Sentry. Each method returns a new instance.
+The `Try` class provides a fluent interface for handling operations with automatic error reporting to Sentry. Each configuration method returns a new instance; terminal methods (`.value()`, `.unwrap()`, `.error()`, `.result()`) execute the wrapped function.
 
 ### Basic Usage
 
 ```typescript
 // With Sentry for Next.js
-import Try from '@power-rent/try-catch/nextjs';
+import { Try } from '@power-rent/try-catch/nextjs';
 // With Sentry for Node
-import Try from '@power-rent/try-catch/node';
+import { Try } from '@power-rent/try-catch/node';
 // With Sentry for Browser
-import Try from '@power-rent/try-catch/browser';
+import { Try } from '@power-rent/try-catch/browser';
 // For custom error reporting service
-import Try from '@power-rent/try-catch';
+import { Try } from '@power-rent/try-catch';
 
 // Execute, get result or undefined, and report errors (never throws)
 const result = await new Try(asyncFunction, arg1, arg2)
@@ -80,7 +157,7 @@ const result = await new Try(asyncFunction, arg1, arg2)
   .value();
 
 // Execute, get result or default value (never throws)
-const result = await new Try(asyncFunction, arg1, arg2)
+const resultWithDefault = await new Try(asyncFunction, arg1, arg2)
   .default('fallback')
   .value();
 
@@ -89,7 +166,7 @@ const error = await new Try(asyncFunction, arg1, arg2).error();
 
 // Report to Sentry and let the error bubble up
 try {
-  const result = await new Try(asyncFunction, arg1, arg2)
+  const unwrapped = await new Try(asyncFunction, arg1, arg2)
     .report('Failed to execute business logic')
     .unwrap();
 } catch (error) {
@@ -99,52 +176,20 @@ try {
 }
 ```
 
-### Parameter Types
-
-The library accepts any parameter types as function arguments:
-
-```typescript
-// String parameters
-const greeting = new Try(greet, 'Alice', 'Hi').value();
-
-// Number parameters
-const sum = new Try(add, 5, 3).unwrap();
-
-// Mixed parameter types
-const message = new Try(formatMessage, 123, 'Test message', true).value();
-
-// No parameters
-const timestamp = new Try(getCurrentTime).value();
-```
-
-Sync functions return values immediately; async functions require `await`.
-
 ### Advanced Usage
 
 ```typescript
 // Chain multiple configuration methods with flexible breadcrumbs
-const result = await new Try(processOrder, 'order-123', { customerId: 456, amount: 99.50 }, { isUrgent: true, retryCount: 3, sensitiveData: {} })
+const result = await new Try(processOrder, 'order-123', { customerId: 456, amount: 99.50 }, { isUrgent: true, retryCount: 3 })
   .breadcrumbs(
-    'orderId', // add to breadcrumbs as { orderId: 'order-123' }
+    'orderId',                                                     // { orderId: 'order-123' }
     (order) => ({ customerId: order.customerId, priceCategory: order.amount > 100 ? 'high' : 'low' }),
-    ['isUrgent', 'retryCount'] // add to breadcrumbs as { isUrgent: true, retryCount: 3 }
+    ['isUrgent', 'retryCount']                                     // { isUrgent: true, retryCount: 3 }
   )
-  .report('Failed to process order')   // Custom error message
-  .tag('operation', 'order-processing') // Add Sentry tag
-  .tag('priority', 'high')            // Add another tag
+  .report('Failed to process order')
+  .tag('operation', 'order-processing')
+  .tag('priority', 'high')
   .default(null)
-  .value();
-
-// Custom transformers work with any parameter types
-const result = await new Try(calculateDistance, 10, 20, 'meters')
-  .breadcrumbs(
-    (x: number) => ({ startX: x }),
-    (y: number) => ({ startY: y }),
-    (unit: string) => ({ measurementUnit: unit })
-  )
-  .report('Distance calculation failed')
-  .tag('operation', 'calculation')
-  .default(0)
   .value();
 
 // Check for errors without throwing
@@ -154,19 +199,17 @@ const error = await new Try(riskyOperation, data)
 
 if (error) {
   console.log('Operation failed:', error.message);
-} else {
-  console.log('Operation succeeded');
 }
 
 // Enable debug logging (opt-in)
-const result = await new Try(problematicFunction, params)
-  .debug() // Logs errors to console.error
+const debugResult = await new Try(problematicFunction, params)
+  .debug()
   .report('Function failed')
   .tag('environment', 'development')
   .value();
 
 // Conditional debug logging
-const result = await new Try(apiCall, endpoint)
+const conditional = await new Try(apiCall, endpoint)
   .debug(process.env.NODE_ENV !== 'production')
   .report('API call failed')
   .value();
@@ -183,38 +226,78 @@ new Try<T, TArgs>(fn: (...args: TArgs) => T | Promise<T>, ...args: TArgs)
 - `fn`: The function to execute (can be sync or async)
 - `args`: Arguments to pass to the function (any types: strings, numbers, objects, etc.)
 
-The constructor accepts any number of arguments of any type. Breadcrumbs functionality supports all parameter types through custom transformer functions.
-
 ### Configuration Methods
 
-All configuration methods return a new `Try` instance, enabling method chaining:
+All configuration methods return the `Try` instance, enabling method chaining:
 
 #### `.report(message: string): Try<T, TArgs>`
 
-Report to Sentry with a custom error message, attach the original error as a cause
+Report to the configured reporter (Sentry in environment-specific entry
+points) with a custom error message; the original error is attached as
+`.cause`.
 
 #### `.breadcrumbs(config): Try<T, TArgs>`
 
 Record breadcrumbs with flexible extraction from any function parameters. The function name is automatically included in all breadcrumbs for better traceability.
 
+**Breadcrumbs are recorded on every terminal method** — `.value()`,
+`.unwrap()`, `.error()`, and `.result()`. The library calls
+`addBreadcrumbsIfConfigured()` on the error path of each terminal, so you
+can use whichever terminal fits your control flow and still get context on
+failure.
+
+```ts doctest
+import { Try, type Reporter, type ErrorReportConfig } from '@power-rent/try-catch';
+
+// Capture a breadcrumb even when the caller picks .error() as the terminal.
+let breadcrumbCalls = 0;
+const recordingReporter: Reporter = {
+  report(_error: Error, _config: ErrorReportConfig): void {},
+  addBreadcrumbs(_data: Record<string, unknown>, _functionName?: string): void {
+    breadcrumbCalls += 1;
+  },
+  createWrappedError(error: Error, message: string): Error {
+    const wrapped = new Error(message);
+    wrapped.cause = error;
+    return wrapped;
+  },
+};
+
+const previous = Try.getDefaultReporter();
+Try.setDefaultReporter(recordingReporter);
+try {
+  const error = new Try(JSON.parse, 'not-json')
+    .breadcrumbs((raw: string) => ({ length: raw.length }))
+    .error();
+  if (!(error instanceof Error)) {
+    throw new Error('expected parse error');
+  }
+  if (breadcrumbCalls !== 1) {
+    throw new Error(`breadcrumbs should fire on .error(), got ${breadcrumbCalls}`);
+  }
+} finally {
+  Try.setDefaultReporter(previous);
+}
+```
+
 **Supports multiple syntax styles:**
 
 ```typescript
-// Variadic transformer functions - transform each parameter
+// Variadic transformer functions — transform each parameter
 .breadcrumbs(
   (id: string) => ({ orderId: id }),
   (amount: number) => ({ amountCategory: amount > 100 ? 'large' : 'small' }),
   (meta: object) => ({ metaKeys: Object.keys(meta).length })
 )
 
-// Array syntax - positional entries
+// Array syntax — positional entries
 .breadcrumbs([
   'value',        // { value: arg0 }
   ['customerId'], // extract keys from arg1 object
   'urgent'        // { urgent: arg2 }
 ])
 
-// Object syntax - parameter index as keys
+// Object syntax — parameter index as keys
 .breadcrumbs({
   0: (url) => ({ endpoint: url }),
   1: ['userId'],
@@ -224,34 +307,56 @@ Record breadcrumbs with flexible extraction from any function parameters. The fu
 
 #### `.tag(name: string, value: string): Try<T, TArgs>`
 
-Add a tag for Sentry error reporting. Can be called multiple times to add multiple tags.
+Add a tag for error reporting. Can be called multiple times to add multiple tags.
+
 #### `.tags({ name1: 'value1', name2: 'value2' }): Try<T, TArgs>`
 
-Add multiple tags for Sentry error reporting. Each call overrides previous tags.
+Add multiple tags at once. Merges with tags previously added via `.tag()`.
 
 #### `.debug(enabled?: boolean): Try<T, TArgs>`
 
-Enable debug logging to console. When enabled, errors will be logged to console.error.
+Enable debug logging to console. When enabled, errors will be logged to
+`console.error`.
 
-### Execution Methods
+### Terminal (Execution) Methods
 
 #### `.unwrap(): T | Promise<Awaited<T>>`
 
-Execute the function and return the result. Throws the original error if one occurred. Will mask the error message if `.report('custom message')` is called in the chain.
+Execute the function and return the result. Throws the original error if
+one occurred (or a wrapped error with your custom message if `.report()`
+was called). Breadcrumbs configured via `.breadcrumbs()` are recorded on
+the error path.
 
-#### `.default<Return>(defaultValue: Return): Try<T, TArgs>`
+#### `.default<D>(defaultValue: D): Try<T, TArgs, D>`
 
-Set a default value that will be returned by `.value()` when an exception occurs.
+Return a new `Try` instance that substitutes `defaultValue` for `.value()`
+when an error occurs. Returns a fresh instance — the original reference is
+unchanged; subsequent `.report()` / `.tag()` calls after `.default()` apply
+only to the returned chain.
 
-#### `.value(): T | undefined | Promise<Awaited<T> | undefined>`
+#### `.value(): T | D | Promise<Awaited<T> | D>`
 
-Execute the function and return the result, the configured default value, or `undefined` if an error occurs.
+Execute the function and return the result, the configured default value,
+or `undefined` (when no default is set) if an error occurs. Breadcrumbs
+are recorded on the error path.
 
 #### `.error(): Error | undefined | Promise<Error | undefined>`
 
-Execute the function and return the error if one occurred, or `undefined` if successful. If `.report()` was configured, the error is reported before being returned.
+Execute the function and return the error if one occurred, or `undefined`
+if successful. If `.report()` was configured, the error is reported before
+being returned. Breadcrumbs are recorded when an error is present.
+
+#### `.result(): TryResult<T> | Promise<TryResult<T>>`
+
+Execute and return a discriminated union:
+`{ success: true; value }` or `{ success: false; error }`. Never throws.
+If `.report()` was configured, the error is reported before the result is
+returned. Breadcrumbs are recorded on the error branch.
 
 Sync functions return values immediately; async functions return Promises.
+`Try` instances are never thenable — `await new Try(fn)` yields the `Try`
+instance itself regardless of whether the wrapped function is sync or async.
+Use `.value()` / `.unwrap()` / `.error()` / `.result()` to execute.
 
 ## Examples
 
@@ -293,11 +398,11 @@ const user = await new Try(fetchUser, { userId: 123, includeProfile: true })
   .report('Failed to fetch user')
   .value();
 
-// Any parameter types (custom transformers available)
+// Custom transformers on any parameter type
 const result = await new Try(processString, 'hello world')
   .breadcrumbs((str: string) => ({
     length: str.length,
-    firstWord: str.split(' ')[0]
+    firstWord: str.split(' ')[0],
   }))
   .report('String processing failed')
   .tag('operation', 'process')
@@ -364,9 +469,9 @@ const result = await new Try(complexOperation, data)
 
 ## Features
 
-- 🚀 **Promise-like interface** - Can be awaited directly
 - 🔍 **Automatic Sentry integration** - Errors are automatically reported
-- 🍞 **Flexible breadcrumb support** - Extract context from any parameter types using transformers
+- 🧱 **Non-Error normalization** — strings, numbers, objects thrown by callers become real `Error` instances with `.cause`
+- 🍞 **Consistent breadcrumbs** — recorded on every terminal method
 - 🏷️ **Tag support** - Add custom tags to Sentry reports
 - 🎯 **TypeScript support** - Full type safety
 - 🔄 **Flexible error handling** - Choose to ignore, use defaults, inspect errors, or let them bubble up
@@ -374,8 +479,8 @@ const result = await new Try(complexOperation, data)
 ## Requirements
 
 - Node.js >= 20
-- TypeScript >= 4.5 (if using TypeScript)
-- Sentry or an alternative error reporting service
+- TypeScript >= 5.0 (if using TypeScript; `const` type parameters are used)
+- Sentry or an alternative error reporting service (optional — falls back to a no-op reporter if not configured)
 
 ## License
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,158 @@
+<!-- generated-by: gsd-doc-writer -->
+# Architecture
+
+## System overview
+
+`@power-rent/try-catch` is a TypeScript library that wraps synchronous and asynchronous functions in a fluent builder API, converting throw-based control flow into typed result values. A caller constructs a `Try` instance around any function, optionally configures error context (message, tags, breadcrumbs), and then resolves the operation through one of four terminal methods: `unwrap`, `value`, `result`, or `error`. The library is runtime-agnostic at its core; Sentry error reporting is layered on via adapter modules that are imported per deployment environment (Node.js, browser, Next.js).
+
+## Component diagram
+
+```mermaid
+graph TD
+    Consumer["Consumer code"]
+    TryClass["core/Try.ts\n(Try class)"]
+    Reporter["core/reporter.ts\n(Reporter interface + NoopReporter)"]
+    BreadcrumbExtractor["utils/breadcrumbs.ts\n(BreadcrumbExtractorUtil)"]
+    Transformers["utils/transformers.ts\n(TransformerRegistry, PredefinedTransformers)"]
+    Types["utils/types.ts\n(BreadcrumbOptions, TryResult, ...)"]
+
+    NodeAdapter["adapters/node/reporter.ts\n(NodeReporter)"]
+    BrowserAdapter["adapters/browser/reporter.ts\n(BrowserReporter)"]
+    NextjsAdapter["nextjs/SentryReporter.ts\n(SentryReporter)"]
+
+    EntryRoot["src/index.ts\n(framework-agnostic entry)"]
+    EntryNode["src/node/index.ts\n(auto-registers NodeReporter)"]
+    EntryBrowser["src/browser/index.ts\n(auto-registers BrowserReporter)"]
+    EntryNextjs["src/nextjs/index.ts\n(auto-registers SentryReporter)"]
+
+    Consumer --> EntryRoot
+    Consumer --> EntryNode
+    Consumer --> EntryBrowser
+    Consumer --> EntryNextjs
+
+    EntryNode --> NodeAdapter
+    EntryBrowser --> BrowserAdapter
+    EntryNextjs --> NextjsAdapter
+
+    NodeAdapter --> Reporter
+    BrowserAdapter --> Reporter
+    NextjsAdapter --> Reporter
+
+    EntryRoot --> TryClass
+    EntryNode --> TryClass
+    EntryBrowser --> TryClass
+    EntryNextjs --> TryClass
+
+    TryClass --> Reporter
+    TryClass --> BreadcrumbExtractor
+    BreadcrumbExtractor --> Transformers
+    Transformers --> Types
+    BreadcrumbExtractor --> Types
+```
+
+## Data flow
+
+A typical call proceeds as follows:
+
+1. **Construction** — `new Try(fn, ...args)` stores the function and its arguments. If `fn` is an `AsyncFunction`, a thenable `.then` property is installed immediately so the instance can be directly `await`-ed. For non-async functions no `.then` is installed, so the instance is not thenable and any thenability probe (e.g. `Promise.resolve`, `util.inspect`, deep-equality matchers) cannot trigger execution.
+2. **Configuration** — The caller chains `.report(message)`, `.breadcrumbs(config)`, `.tag(name, value)`, `.tags({...})`, `.default(fallback)`, `.debug()`, and/or `.finally(callback)`. Each method mutates internal config and returns `this`.
+3. **Execution** — A terminal method (`unwrap`, `value`, `result`, or `error`) calls the private `execute()` method. `execute()` invokes `fn(...args)` inside a `try/catch`. If the return value is thenable, execution continues asynchronously via `Promise.resolve(value).then(...).catch(...).finally(...)`. Otherwise it settles synchronously. Results are cached so repeated terminal calls do not re-invoke the function.
+4. **Thrown-value normalization** — Both the synchronous `catch (e)` arm of `execute()` and the async `.catch(...)` branch pass the thrown value through `Try.normalizeThrown`. If `e instanceof Error`, it is returned unchanged. Otherwise a fresh `Error` is constructed with `message === 'Non-Error thrown (<typeof e>)'` and the original value preserved on `.cause`. Downstream terminals and the `Reporter` contract therefore always see an `Error` instance — callers never need to re-check `typeof err`.
+5. **Error handling** — On failure:
+   - If the error's `name` appears in `Try.throwThroughErrorTypes`, `.report()` is short-circuited: `reportError()` is NOT called and (for `unwrap`) the original error is re-thrown as-is. If `.breadcrumbs()` was configured, `addBreadcrumbsIfConfigured()` still runs.
+   - Otherwise, if `.report()` was configured, `reportError()` runs, which:
+     - Calls `addBreadcrumbsIfConfigured()` to extract context from arguments via `BreadcrumbExtractorUtil.extract`.
+     - Calls `Try.defaultReporter.report(error, config)` — the active `Reporter` implementation sends the event to Sentry.
+     - For `unwrap`, a wrapped `Error` (original as `.cause`) is thrown with the configured `.report()` message.
+   - If neither `.report()` nor throw-through applies, terminals still invoke `addBreadcrumbsIfConfigured()` when `.breadcrumbs()` is configured (see below).
+6. **Finally callback** — `runFinallyCallback()` executes the registered `.finally()` callback exactly once after the function settles, regardless of success or failure. Async callbacks are awaited; errors inside the callback are swallowed (logged when `debug` is enabled).
+
+When `.report()` is **not** configured but `.breadcrumbs()` is, each terminal method still invokes `addBreadcrumbsIfConfigured()` on its error branch — `value()`, `unwrap()`, `error()`, and `result()` all share the same breadcrumb-recording path. `addBreadcrumbsIfConfigured()` is internally idempotent (guarded by `local.breadcrumbsAdded`), so chaining `.report()` and another terminal in the same instance never double-records.
+
+## Key abstractions
+
+| Abstraction | File | Description |
+|---|---|---|
+| `Try<TReturn, TArgs, TDefault>` | `src/core/Try.ts` | Central builder class; owns execution, caching, and result dispatch |
+| `TryResult<T>` | `src/core/Try.ts` | Discriminated union `{ success: true; value }` / `{ success: false; error }` |
+| `Reporter` | `src/core/reporter.ts` | Interface with `report`, `addBreadcrumbs`, and `createWrappedError` methods |
+| `NoopReporter` | `src/core/reporter.ts` | Default no-op implementation; active when no environment adapter is loaded |
+| `NodeReporter` | `src/adapters/node/reporter.ts` | Sentry reporter using `@sentry/node` |
+| `BrowserReporter` | `src/adapters/browser/reporter.ts` | Sentry reporter using `@sentry/browser` |
+| `SentryReporter` | `src/nextjs/SentryReporter.ts` | Sentry reporter using `@sentry/nextjs` |
+| `BreadcrumbExtractorUtil` | `src/utils/breadcrumbs.ts` | Dispatches all breadcrumb config formats to the correct extraction strategy |
+| `TransformerRegistry` | `src/utils/transformers.ts` | Applies custom and predefined (`length`, `type`, `value`, `toString`) breadcrumb transformers |
+| `BreadcrumbOptions<TArgs>` | `src/utils/types.ts` | Union type covering all three breadcrumb syntaxes: string-key array, positional array, object map |
+
+## Sync vs async execution paths
+
+The library resolves the sync/async split at terminal-method call time. `Try` instances are **never thenable** — no `.then` is ever installed — so `await new Try(fn)` always yields the `Try` instance itself without triggering execution. Any thenability probe (`Promise.resolve`, `util.inspect`, deep-equality matchers, serializers) is guaranteed not to invoke the wrapped function.
+
+Callers consume the result with `.value()`, `.unwrap()`, `.result()`, or `.error()`. Each terminal routes through `execute()`:
+
+**Async path (declared `async` functions)**
+`fn.constructor.name === 'AsyncFunction'` is true. The terminal returns a `Promise<...>` that callers `await`.
+
+**Non-async path (everything else)**
+The terminal runs synchronously. If the wrapped function happens to return a `Promise`, `execute()` detects it and returns a `Promise<TryResult>` so `await` still works on the terminal call.
+
+Both paths cache the result in `this.exec` so that subsequent terminal method calls return the same settled value.
+
+## Reporter integration strategy
+
+All reporter implementations are **external** to the core `Try` class. The class holds a single static `Try.defaultReporter: Reporter` (initially `NoopReporter`). Environment-specific entry points call `Try.setDefaultReporter(new XxxReporter())` as a side effect on import:
+
+| Entry point | Side effect |
+|---|---|
+| `@power-rent/try-catch/node` | Registers `NodeReporter` (`@sentry/node`) |
+| `@power-rent/try-catch/browser` | Registers `BrowserReporter` (`@sentry/browser`) |
+| `@power-rent/try-catch/nextjs` | Registers `SentryReporter` (`@sentry/nextjs`) |
+| `@power-rent/try-catch` (root) | No reporter registered; stays `NoopReporter` |
+
+All Sentry packages are declared as `devDependencies` only and listed as `external` in `tsup.config.ts`, so they are never bundled. Consumers must supply the matching Sentry SDK version (`>=8.0.0 <11.0.0`) in their own project.
+
+## Build outputs
+
+The build is driven by `tsup` (v8) with config at `tsup.config.ts`. Entry points are derived automatically from the `exports` field in `package.json`. Two parallel builds are produced:
+
+| Format | Output directory | Declaration files |
+|---|---|---|
+| CJS (`require`) | `dist/` | Yes (`.d.ts` alongside each `.js`) |
+| ESM (`import`) | `dist/esm/` | No (CJS declarations serve both) |
+
+Both formats target `es2020`, emit sourcemaps, and use `.js` extensions (tsup's default `.mjs` for ESM is overridden via `esbuildOptions`). Splitting is disabled; each entry point produces a single file. The resulting `dist/` layout mirrors the `exports` map:
+
+```
+dist/
+  index.js          # root CJS entry
+  index.d.ts
+  node/index.js
+  browser/index.js
+  nextjs/index.js
+  esm/
+    index.js        # root ESM entry
+    node/index.js
+    browser/index.js
+    nextjs/index.js
+```
+
+## Directory structure rationale
+
+```
+src/
+  core/           # Framework-agnostic Try class and Reporter interface
+  adapters/
+    node/         # NodeReporter using @sentry/node
+    browser/      # BrowserReporter using @sentry/browser
+  nextjs/         # Next.js entry + SentryReporter using @sentry/nextjs
+  node/           # Node.js package entry point (registers NodeReporter)
+  browser/        # Browser package entry point (registers BrowserReporter)
+  utils/
+    types.ts      # All breadcrumb TypeScript types
+    breadcrumbs.ts# BreadcrumbExtractorUtil — config dispatch logic
+    transformers.ts# TransformerRegistry + PredefinedTransformers
+  index.ts        # Root package entry (no reporter side effects)
+  __tests__/      # Vitest test suite
+```
+
+`adapters/` holds the reporter implementations separate from the entry points so that the entry points remain thin (import + one `setDefaultReporter` call). `core/` contains zero environment-specific imports, making it safe to tree-shake in any bundler.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,0 +1,187 @@
+<!-- generated-by: gsd-doc-writer -->
+# Configuration
+
+This document covers all configuration files used to build, lint, test, and publish `@power-rent/try-catch`.
+
+## Environment Variables
+
+The library itself ships no runtime environment-variable requirements. The single `process.env` reference in source code is a documentation example showing how callers might pass `process.env.NODE_ENV === 'development'` to `.debug()`. No variable is read at library initialisation time.
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `NODE_ENV` | Optional | — | Not read by the library. Shown in docs as an example argument to `.debug()`. |
+
+## Package Exports
+
+`package.json` exposes four entry points via the `exports` field.
+
+| Subpath | CJS (`require`) | ESM (`import`) | Types |
+|---------|----------------|----------------|-------|
+| `.` (default) | `dist/index.js` | `dist/esm/index.js` | `dist/index.d.ts` |
+| `./nextjs` | `dist/nextjs/index.js` | `dist/esm/nextjs/index.js` | `dist/nextjs/index.d.ts` |
+| `./node` | `dist/node/index.js` | `dist/esm/node/index.js` | `dist/node/index.d.ts` |
+| `./browser` | `dist/browser/index.js` | `dist/esm/browser/index.js` | `dist/browser/index.d.ts` |
+
+Legacy fields for bundlers that do not read `exports`:
+
+| Field | Value |
+|-------|-------|
+| `main` | `dist/index.js` |
+| `module` | `dist/esm/index.js` |
+| `types` | `dist/index.d.ts` |
+
+The `typesVersions` field mirrors the same four subpaths so older TypeScript resolvers find declaration files correctly.
+
+The `nextjs`, `node`, and `browser` entry points are marked as `sideEffects` because they register platform-specific Sentry reporters at import time.
+
+## Build Configuration (`tsup.config.ts`)
+
+The build is driven by [tsup](https://tsup.egoist.dev/) and produces two output formats in a single run.
+
+| Setting | Value |
+|---------|-------|
+| Tool | tsup 8.x (wraps esbuild) |
+| Entry points | Derived dynamically from `package.json` `exports` field |
+| CJS output directory | `dist/` |
+| ESM output directory | `dist/esm/` |
+| Target | `es2020` |
+| Platform | `neutral` (compatible with Node, browser, and Next.js entries) |
+| Sourcemaps | Enabled (sources embedded by esbuild) |
+| Minification | Disabled |
+| Code splitting | Disabled (one file per entry) |
+| Output extension | `.js` for both formats (esbuild `outExtension` override) |
+| Declaration types | Generated for CJS build only (`dts: true` with `resolve: true`) |
+| External packages | All Sentry packages (`@sentry/core`, `@sentry/node`, `@sentry/browser`, `@sentry/nextjs`, `@sentry/tracing`, `@sentry/types`, `@sentry/utils`, `@sentry/react`, `@sentry/integrations`) plus any declared `peerDependencies` |
+
+To trigger a full build:
+
+```bash
+npm run build
+```
+
+This runs `clean` → `typecheck` → `tsup`.
+
+## TypeScript Configuration
+
+Two tsconfig files govern the TypeScript compiler.
+
+### `tsconfig.json` (CJS / type-checking)
+
+| Option | Value |
+|--------|-------|
+| `target` | `ES2022` |
+| `module` | `CommonJS` |
+| `lib` | `["ES2022"]` |
+| `outDir` | `dist` |
+| `declaration` | `true` |
+| `declarationMap` | `true` |
+| `sourceMap` | `true` |
+| `strict` | `true` |
+| `noImplicitAny` | `true` |
+| `esModuleInterop` | `true` |
+| `allowSyntheticDefaultImports` | `true` |
+| `forceConsistentCasingInFileNames` | `true` |
+| `skipLibCheck` | `true` |
+| `moduleResolution` | `node` |
+| `include` | `src/**/*` |
+| `exclude` | `node_modules`, `dist` |
+
+This config is also used by the ESLint TypeScript parser (`parserOptions.project`).
+
+### `tsconfig.esm.json` (ESM build)
+
+Extends `tsconfig.json` with overrides:
+
+| Option | Value |
+|--------|-------|
+| `module` | `ES2022` |
+| `target` | `ES2020` |
+| `outDir` | `dist/esm` |
+
+## Lint Configuration (`eslint.config.mjs`)
+
+Uses [typescript-eslint](https://typescript-eslint.io/) flat config.
+
+| Setting | Value |
+|---------|-------|
+| Base config | `tseslint.configs.strictTypeChecked` |
+| Parser project | `./tsconfig.json` |
+| Ignored paths | `dist/**`, `node_modules/**`, `examples/**`, `eslint.config.mjs` |
+
+Notable rule overrides (apply globally — main rules block has no `files` filter):
+
+| Rule | Level | Reason |
+|------|-------|--------|
+| `@typescript-eslint/no-explicit-any` | `error` | |
+| `@typescript-eslint/no-unsafe-argument` | `error` | |
+| `@typescript-eslint/no-unsafe-assignment` | `error` | |
+| `@typescript-eslint/no-unsafe-return` | `error` | |
+| `@typescript-eslint/no-unsafe-call` | `error` | |
+| `@typescript-eslint/no-unsafe-member-access` | `error` | |
+| `@typescript-eslint/no-extraneous-class` | `off` | Static-only utility classes used as namespaces |
+| `@typescript-eslint/no-unnecessary-type-parameters` | `off` | Nominal API clarity |
+| `@typescript-eslint/unified-signatures` | `off` | Deliberate overload separation for IDE UX |
+| `@typescript-eslint/restrict-template-expressions` | `error` (`allowNumber: true`) | |
+| `@typescript-eslint/no-empty-object-type` | `off` | Sentinel use in tuple index types |
+| `@typescript-eslint/no-unused-vars` | `error` (ignore `^_` prefix) | |
+
+Test files (`src/__tests__/**`) relax all unsafe rules and several others to accommodate type-assertion-heavy tests.
+
+To run the linter:
+
+```bash
+npm run lint
+```
+
+## Format Configuration (`.prettierrc`)
+
+| Option | Value |
+|--------|-------|
+| `singleQuote` | `true` |
+| `jsxSingleQuote` | `true` |
+| `endOfLine` | `lf` |
+
+Ignored by Prettier: `dist/`, `node_modules/`, all `*.md` files (`.prettierignore`).
+
+```bash
+npm run format        # write changes
+npm run format:check  # check only (used in CI)
+```
+
+## Test Configuration (`vite.config.ts`)
+
+Tests run with [Vitest](https://vitest.dev/).
+
+| Setting | Value |
+|---------|-------|
+| Environment | `node` |
+| Globals | Enabled (`globals: true`) |
+| Coverage provider | `v8` |
+| Coverage include | `src/**/*.ts` |
+| `resolve.alias` | Maps `@power-rent/try-catch` and its `/node`, `/browser`, `/nextjs` subpaths to the corresponding entry under `src/` so docs/doctest snippets can `import` the package by its published name. Order matters — sub-path aliases are matched before the bare package alias. |
+
+No coverage threshold is configured.
+
+```bash
+npm run test        # single run
+npm run test:watch  # watch mode
+```
+
+## Dependency Update Configuration (`renovate.json`)
+
+Renovate is configured with the `config:recommended` preset, which enables automatic dependency update PRs with grouping and scheduling defaults defined by that preset.
+
+```json
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"]
+}
+```
+
+## Runtime Requirement
+
+```
+node >= 20
+```
+
+Defined in `package.json` `engines.node`.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,161 @@
+<!-- generated-by: gsd-doc-writer -->
+# Development
+
+## Local setup
+
+Requirements: Node.js >= 20 (see `package.json` `engines`).
+
+```bash
+git clone https://github.com/Toprent-app/try-catch.git
+cd try-catch
+npm install
+```
+
+No `.env` file is required — the library has no runtime environment variables (see `docs/CONFIGURATION.md`).
+
+### Git worktrees
+
+Active feature branches live under `.worktrees/`. To work on a branch in isolation:
+
+```bash
+git worktree add .worktrees/my-feature origin/my-feature
+cd .worktrees/my-feature
+npm install
+```
+
+Each worktree shares the parent repo's `.git` directory but has its own working tree and `node_modules`.
+
+## Build commands
+
+| Command | Description |
+|---|---|
+| `npm run build` | Clean, typecheck, then compile CJS + ESM via tsup |
+| `npm run build:watch` | tsup in watch mode — recompiles on file save |
+| `npm run typecheck` | `tsc --noEmit` against `tsconfig.json` (CJS settings) |
+| `npm run lint` | ESLint over `src/**/*.ts` using `typescript-eslint` |
+| `npm run format` | Prettier — write changes in place |
+| `npm run format:check` | Prettier — check only (used in CI) |
+| `npm run test` | Vitest single run |
+| `npm run test:watch` | Vitest interactive watch mode |
+| `npm run clean` | Delete `dist/` |
+| `npm run changeset` | Open a changeset entry for the next release |
+| `npm run changeset:version` | Bump version from pending changesets |
+| `npm run changeset:publish` | Publish to npm from bumped version |
+
+The `prepublishOnly` script enforces `clean → lint → test → build` before any `npm publish`.
+
+### Watch mode during development
+
+```bash
+npm run build:watch
+```
+
+tsup rebuilds both CJS (`dist/`) and ESM (`dist/esm/`) outputs on every save. Entry points are derived automatically from the `exports` field in `package.json` — no manual tsup entry list is needed.
+
+## Directory layout
+
+```
+src/
+  index.ts            # Framework-agnostic entry — exports Try and core types
+  core/
+    Try.ts            # Main Try class (lazy execution, sync + async)
+    reporter.ts       # Reporter interface, ErrorReportConfig, NoopReporter
+  adapters/
+    browser/
+      reporter.ts     # BrowserReporter — wraps @sentry/browser
+    node/
+      reporter.ts     # NodeReporter — wraps @sentry/node
+  nextjs/
+    index.ts          # Auto-registers SentryReporter for Next.js
+    SentryReporter.ts # Next.js Sentry reporter
+  browser/
+    index.ts          # Auto-registers BrowserReporter
+  node/
+    index.ts          # Auto-registers NodeReporter
+  utils/
+    breadcrumbs.ts    # BreadcrumbExtractorUtil
+    transformers.ts   # TransformerRegistry, PredefinedTransformers
+    types.ts          # Shared types (BreadcrumbOptions, TryResult, ...)
+  __tests__/
+    adapters/
+      browser.test.ts
+      node.test.ts
+      nextjs.test.ts
+    docs/
+      __fixtures__/
+      doctest-extract.ts
+      doctest-extract.test.ts
+      doctest.test.ts
+      README.md
+    Try.test.ts
+    all-usecases.test.ts
+    flexible-breadcrumbs.test.ts
+    type-safety.test.ts
+docs/
+  ARCHITECTURE.md
+  CONFIGURATION.md
+  DEVELOPMENT.md
+  GETTING-STARTED.md
+  TESTING.md
+.planning/            # Phase planning context (not shipped)
+  phases/
+    01-core-try-semantics/
+    ...
+```
+
+## Code style
+
+**ESLint** (`eslint.config.mjs`) uses `typescript-eslint` recommended rules. Run:
+
+```bash
+npm run lint
+```
+
+**Prettier** (`prettier` in devDependencies) handles formatting. Run:
+
+```bash
+npm run format        # fix in place
+npm run format:check  # check only
+```
+
+**TypeScript** strict mode is enabled (`strict: true`, `noImplicitAny: true`). Typecheck separately from the build:
+
+```bash
+npm run typecheck
+```
+
+## Adding a new reporter adapter
+
+A reporter adapter connects the library to an error-tracking service. The contract is the `Reporter` interface in `src/core/reporter.ts`:
+
+```typescript
+export interface Reporter {
+  report(error: Error, config: ErrorReportConfig): void;
+  addBreadcrumbs(data: Record<string, unknown>, functionName?: string): void;
+  createWrappedError(error: Error, message: string): Error;
+}
+```
+
+Steps to add a new adapter (e.g., for Bugsnag):
+
+1. Create `src/adapters/bugsnag/reporter.ts` implementing `Reporter`.
+2. Create `src/bugsnag/index.ts` that instantiates the reporter and registers it (follow `src/node/index.ts` as a reference).
+3. Add a `"./bugsnag"` entry to the `exports` field in `package.json` pointing to the new entry file. tsup will pick it up automatically from the `exports` field.
+4. Add `@bugsnag/*` to the `external` list in `tsup.config.ts` under `sentryManual` (or use `peerDependencies`).
+5. Add `"./bugsnag": ["dist/bugsnag/index.d.ts"]` to `typesVersions` in `package.json`.
+6. Write tests in `src/__tests__/` covering the new adapter.
+
+## Planning directory
+
+`.planning/` contains phase context documents used during active feature development. These files are not published. Each phase directory holds a `CONTEXT.md` (gathered facts and decisions) and, once complete, a `SUMMARY.md` (outcome record). Do not delete them during rebases — they serve as a decision log.
+
+## Branch conventions
+
+No formal convention is documented. The main branch is `main`. Feature branches currently follow a descriptive slug pattern (e.g., `try-sync-returns`). Active branches are isolated via git worktrees under `.worktrees/`.
+
+## PR process
+
+- Open a pull request against `main`.
+- The `prepublishOnly` gate (`lint → test → build`) must pass locally before pushing.
+- The CI workflow (`.github/workflows/ci.yml`) runs `tsc --noEmit` and `npm run test` on every push and pull request to `main` (Node.js 20.x, `ubuntu-latest`). PRs must be green before merge.
+- Include a changeset entry (`npm run changeset`) if the change affects the public API or fixes a bug consumers would notice.

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -1,0 +1,167 @@
+<!-- generated-by: gsd-doc-writer -->
+# Getting Started
+
+## Prerequisites
+
+- Node.js `>= 20` (defined in `package.json` `engines.node`)
+- TypeScript `>= 5.0` when using TypeScript (`const` type parameters are used)
+- A Sentry SDK for your runtime (`@sentry/node`, `@sentry/browser`, or `@sentry/nextjs` — version `>=8.0.0 <11.0.0`) if you want error reporting. The library works without Sentry via the built-in `NoopReporter`.
+
+## Installation
+
+```bash
+npm install @power-rent/try-catch
+```
+
+## Choose Your Entry Point
+
+The package ships four entry points. Import the one that matches your runtime. Each environment-specific entry point auto-registers the correct Sentry reporter as a side effect on import.
+
+| Entry point | Import path | Sentry SDK required |
+|---|---|---|
+| Node.js | `@power-rent/try-catch/node` | `@sentry/node` |
+| Browser / bundler | `@power-rent/try-catch/browser` | `@sentry/browser` |
+| Next.js | `@power-rent/try-catch/nextjs` | `@sentry/nextjs` |
+| Plain / custom reporter | `@power-rent/try-catch` | none |
+
+## First Use by Environment
+
+### Node.js
+
+```typescript
+import { Try } from '@power-rent/try-catch/node';
+
+const data = await new Try(fetchFromDatabase, { userId: 42 })
+  .report('Failed to fetch user')
+  .default(null)
+  .value();
+```
+
+### Next.js (App Router or Pages Router)
+
+```typescript
+import { Try } from '@power-rent/try-catch/nextjs';
+
+export async function GET() {
+  const user = await new Try(getUser, requestContext)
+    .report('Failed to load user in route handler')
+    .default(null)
+    .value();
+
+  return Response.json({ user });
+}
+```
+
+### Browser / Client-Side Bundler
+
+```typescript
+import { Try } from '@power-rent/try-catch/browser';
+
+const result = await new Try(callApi, '/api/orders')
+  .report('API call failed')
+  .default([])
+  .value();
+```
+
+### Plain (No Sentry / Custom Reporter)
+
+Use the root entry point when you have no Sentry SDK or want to supply your own reporter. Errors are silently swallowed by the built-in `NoopReporter` unless you register a custom one.
+
+```typescript
+import { Try, NoopReporter } from '@power-rent/try-catch';
+
+// Default: errors are not reported anywhere
+const value = await new Try(riskyFn, arg).value();
+
+// Provide your own reporter
+import { Try } from '@power-rent/try-catch';
+import type { Reporter, ErrorReportConfig } from '@power-rent/try-catch';
+
+class ConsoleReporter implements Reporter {
+  report(error: Error, config: ErrorReportConfig): void {
+    console.error(config.message ?? error.message, error);
+  }
+  addBreadcrumbs(data: Record<string, unknown>, functionName?: string): void {
+    console.log('breadcrumbs', functionName, data);
+  }
+  createWrappedError(error: Error, message: string): Error {
+    const wrapped = new Error(`${message}: ${error.message}`);
+    wrapped.cause = error;
+    return wrapped;
+  }
+}
+
+Try.setDefaultReporter(new ConsoleReporter());
+```
+
+## Sync vs Async
+
+`Try` instances are never thenable. Whether the wrapped function is sync or async, you must call a terminal method (`.value()`, `.unwrap()`, `.error()`, or `.result()`) to run it and read the outcome.
+
+**Async functions** — `await` the terminal method:
+
+```ts doctest
+import { Try } from '@power-rent/try-catch';
+
+async function asyncFn(arg: number) {
+  return arg * 2;
+}
+
+const result = await new Try(asyncFn, 21).value();
+
+if (result !== 42) {
+  throw new Error(`expected 42, got ${String(result)}`);
+}
+```
+
+**Sync functions (and sync fns returning a Promise)** — call a terminal method:
+
+```ts doctest
+import { Try } from '@power-rent/try-catch';
+
+const rawString = '{"ok":true}';
+
+// Sync function: call terminal method without await
+const result = new Try(JSON.parse, rawString).value();
+
+// Sync fn that returns a Promise: terminal methods still handle it.
+function returnsPromise(): Promise<number> {
+  return Promise.resolve(42);
+}
+const n = await new Try(returnsPromise).value();
+
+// Awaiting a Try instance directly yields the Try instance, NOT the result.
+// The instance is not thenable, so `await` cannot trigger execution.
+// Use .value() / .unwrap() / .error() / .result() instead.
+if ((result as { ok: boolean }).ok !== true || n !== 42) {
+  throw new Error('sync .value() path failed');
+}
+```
+
+If you are unsure whether a function is async, using `.value()` without `await` is always safe for sync functions, and using `await .value()` is always safe for async functions.
+
+## Common Setup Issues
+
+**Wrong entry point imported** — If errors are never sent to Sentry, ensure you imported a runtime-specific entry point (`/node`, `/browser`, or `/nextjs`) rather than the root `@power-rent/try-catch`. The root entry registers a `NoopReporter` by default.
+
+**Sentry SDK not installed** — The library declares all Sentry packages as `devDependencies` and never bundles them. You must add the matching Sentry SDK to your project:
+
+```bash
+# Node.js
+npm install @sentry/node
+
+# Browser
+npm install @sentry/browser
+
+# Next.js
+npm install @sentry/nextjs
+```
+
+Supported version range: `>=8.0.0 <11.0.0`.
+
+**`await new Try(fn)` returns the `Try` instance** — This is expected behaviour for every wrapped function (sync or async). `Try` instances are not thenable, so `await` cannot trigger execution. Use `.value()`, `.unwrap()`, `.error()`, or `.result()` to retrieve the result.
+
+## Next Steps
+
+- See [ARCHITECTURE.md](./ARCHITECTURE.md) for an overview of how the library is structured internally, including the sync/async execution paths and the reporter integration model.
+- The full API reference (constructor, configuration methods, terminal methods) is documented in the [API section of README.md](../README.md#api).

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,163 @@
+<!-- generated-by: gsd-doc-writer -->
+# Testing
+
+## Test framework and setup
+
+The project uses **Vitest** (`^4.0.3`) as its test runner. No additional setup is required beyond installing dependencies.
+
+```bash
+npm install
+```
+
+Configuration is in `vite.config.ts`:
+
+```ts
+{
+  test: {
+    environment: 'node',
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+    },
+  },
+}
+```
+
+The `globals: true` setting makes `describe`, `it`, `expect`, and `vi` available without explicit imports (though test files in this project import them explicitly from `vitest`).
+
+## Running tests
+
+**Run the full test suite (one-shot):**
+
+```bash
+npm test
+```
+
+This runs `vitest run` — executes all tests and exits.
+
+**Watch mode (re-runs on file change):**
+
+```bash
+npm run test:watch
+```
+
+This runs `vitest` without the `run` flag.
+
+**Run a single file:**
+
+```bash
+npx vitest run src/__tests__/Try.test.ts
+```
+
+**Run with coverage:**
+
+```bash
+npx vitest run --coverage
+```
+
+Coverage is collected via the V8 provider and includes all files matching `src/**/*.ts`.
+
+## Test file structure and naming conventions
+
+All test files live under `src/__tests__/` and follow the `*.test.ts` naming pattern:
+
+| File | What it covers |
+|---|---|
+| `src/__tests__/Try.test.ts` | Core behaviour — async and sync paths, error handling, Sentry reporting, breadcrumbs, tags, `finally`, `result()`, `default()`, exec-state sharing |
+| `src/__tests__/all-usecases.test.ts` | Type-level and runtime surface — construction, result methods, `PromiseLike`/`await` behaviour, `.default()`, `.breadcrumbs()` overloads, chain methods, statics, `TryResult` narrowing |
+| `src/__tests__/flexible-breadcrumbs.test.ts` | The full breadcrumb extraction API — key arrays, extractor objects, variadic transformers, object-syntax config, error handling, edge cases, caching |
+| `src/__tests__/type-safety.test.ts` | TypeScript type assertions using `expectTypeOf` — value/error/unwrap return types, breadcrumb key validation, invalid argument rejection |
+| `src/__tests__/adapters/node.test.ts` | `NodeReporter` adapter — Sentry `@sentry/node` mock-based assertions |
+| `src/__tests__/adapters/browser.test.ts` | `BrowserReporter` adapter — Sentry `@sentry/browser` mock-based assertions |
+| `src/__tests__/adapters/nextjs.test.ts` | `SentryReporter` (Next.js) adapter — Sentry `@sentry/nextjs` mock-based assertions |
+| `src/__tests__/docs/doctest.test.ts` | Doctest harness — executes every ` ```ts doctest``` `-tagged snippet in `README.md`, `docs/*.md`, and `src/__tests__/docs/__fixtures__/*.md` with `NoopReporter` + mocked Sentry |
+| `src/__tests__/docs/doctest-extract.test.ts` | Unit tests for the marker-based fenced-block extractor that feeds the doctest harness |
+
+## Doc verification harness
+
+The doctest harness (introduced in Phase 3 Wave 1) auto-executes TypeScript
+snippets embedded in user-facing docs so examples cannot drift from real
+behavior. Mark a fenced block with the ` ```ts doctest ` (or
+` ```typescript doctest `) info string to opt it in:
+
+````markdown
+```ts doctest
+import { Try } from '@power-rent/try-catch';
+const value = await new Try(() => 42).value();
+if (value !== 42) throw new Error('drift detected');
+```
+````
+
+Scanned surface: `README.md`, every `docs/*.md`, and any `*.md` under
+`src/__tests__/docs/__fixtures__/`. The runner sets `NoopReporter` as the
+default reporter before each snippet (restored after), `vi.mock`s
+`@sentry/node`, `@sentry/browser`, and `@sentry/nextjs`, and wires vitest
+aliases so snippets can import from `@power-rent/try-catch[/sub]` as a real
+consumer would. See `src/__tests__/docs/README.md` for the full marker
+convention, execution contract, and checklist before adding a snippet.
+
+## Writing new tests
+
+Add a file to `src/__tests__/` with a `.test.ts` extension. Import helpers explicitly from `vitest`:
+
+```ts
+import { describe, it, expect, vi, afterEach } from 'vitest';
+```
+
+**Mocking Sentry** — tests that exercise `.report()`, `.breadcrumbs()`, or `.tag()` must mock the relevant Sentry package before importing `Try`. Declare the mock at the top of the file using `vi.mock`:
+
+```ts
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+  addBreadcrumb: vi.fn(),
+}));
+
+import * as Sentry from '@sentry/nextjs';
+```
+
+The same pattern applies for `@sentry/node` and `@sentry/browser` when testing those entry points.
+
+**Resetting mocks between tests** — use `afterEach` to clear call history and restore spies:
+
+```ts
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.restoreAllMocks();
+  Try.throwThroughErrorTypes([]); // reset static state if modified
+});
+```
+
+**Spying on `console.error`** — tests that assert debug logging mock the method inline and restore it after:
+
+```ts
+const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+// ... assertions ...
+consoleSpy.mockRestore();
+```
+
+**Type assertions** — use `expectTypeOf` from `vitest` (imported explicitly) for compile-time type checks alongside runtime assertions. See `src/__tests__/type-safety.test.ts` and `src/__tests__/all-usecases.test.ts` for examples using `@ts-expect-error` to assert that invalid usages are rejected by the type system.
+
+## Coverage requirements
+
+No coverage thresholds are configured in `vite.config.ts`. The coverage section specifies the provider and included files only:
+
+```ts
+coverage: {
+  provider: 'v8',
+  include: ['src/**/*.ts'],
+}
+```
+
+No minimum line, branch, function, or statement coverage is enforced.
+
+## CI integration
+
+Tests run in the **CI** workflow (`.github/workflows/ci.yml`) on every push and pull request to `main`.
+
+| Step | Command |
+|---|---|
+| Type check | `npx tsc --noEmit` |
+| Run tests | `npm run test` |
+
+The workflow runs on `ubuntu-latest` with Node.js `20.x`. Tests must pass before a PR can be merged.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,201 +1,42 @@
-# Try-Catch Library Examples
+# Examples
 
-This directory contains comprehensive examples demonstrating all features and usage patterns of the try-catch library.
+Two runnable TypeScript files plus a dedicated tsconfig that type-checks them against the local `src/`.
 
-## Available Examples
+## Files
 
-### 1. `comprehensive-examples.ts`
-**The main examples file** - A complete demonstration of all library features including:
+### `comprehensive-examples.ts`
 
-- **Basic Usage Patterns**: Different parameter types, error handling fundamentals
-- **Error Handling Strategies**: `.unwrap()`, `.value()`, `.error()`, `.result()`, default values
-- **Breadcrumb Patterns**: Key extraction, transformers, object syntax, mixed strategies
-- **Platform-Specific Examples**: Node.js, Browser, and Next.js specific usage
-- **Real-World Service Patterns**: API clients, service layers, repository pattern
-- **Advanced Configuration**: Debug logging, finally callbacks, error type filtering, complex tagging
-- **Testing Patterns**: Custom reporters, performance testing, error validation
+A curated tour of the current `@power-rent/try-catch` API. It exercises every method on the `Try` class — `.value()`, `.unwrap()`, `.error()`, `.result()`, `.default()`, `.finally()`, `.debug()`, `.report()`, `.breadcrumbs()` (all four variants: key arrays, variadic transformers, index-keyed object, extractor objects), `.tag()`, `.tags()`, `Try.setDefaultReporter`, `Try.throwThroughErrorTypes` — plus the non-Error normalization contract and the breadcrumbs-on-every-terminal guarantee. Organized into labeled sections that mirror the README API tour.
 
-### 2. `custom-reporter.ts`
-Demonstrates how to create and use custom error reporters instead of the default Sentry integration.
+### `custom-reporter.ts`
 
-## Running the Examples
+A minimal implementation of the current three-method `Reporter` interface (`report`, `addBreadcrumbs`, `createWrappedError`). The `ConsoleReporter` class it defines is the same contract every bundled adapter (`src/adapters/node`, `src/adapters/browser`, `src/nextjs/SentryReporter`) follows. Use it as a starting point for wiring Datadog, Honeycomb, an in-memory test collector, or any other backend.
 
-### Prerequisites
-- Node.js >= 18
-- This project's dependencies installed (`npm install`)
+## Running the examples
 
-### Quick Start
+No TypeScript runner is pinned as a dev-dependency in this repo. Install one locally to execute the files directly:
 
 ```bash
-# Run the comprehensive examples (recommended)
+npm install -D tsx
 npx tsx examples/comprehensive-examples.ts
-
-# Alternative with ts-node (requires building first)
-npm run build
-npx ts-node examples/comprehensive-examples.ts
-
-# Run custom reporter example
 npx tsx examples/custom-reporter.ts
 ```
 
-### Building First (Optional)
-If you encounter module resolution issues, build the project first:
+The default reporter registered in `comprehensive-examples.ts` is `NoopReporter`, so running it produces no side effects beyond its own `console.log` calls. Swap in `ConsoleReporter` from `custom-reporter.ts` (or your own `Reporter`) to see reports flow end-to-end.
+
+## Type-checking these examples
+
+The examples have their own tsconfig so they can be verified independently of the package build:
 
 ```bash
-npm run build
+npx tsc -p examples
 ```
 
-## What You'll Learn
+`examples/tsconfig.json` extends the project tsconfig, sets `noEmit: true`, and uses `paths` to resolve `@power-rent/try-catch` and its `/node`, `/browser`, `/nextjs` sub-paths to the local `src/` tree. That means examples import from the exact package name a consumer would use in application code while still being fully type-checked against the current source.
 
-### Basic Usage
-```typescript
-// Simple async error handling
-const user = await new Try(fetchUser, 'user-123').value();
+The root `npx tsc --noEmit` only covers `src/**/*` (see `tsconfig.json`), so use `npx tsc -p examples` to verify changes to this directory.
 
-// Multiple parameter types
-const message = await new Try(formatMessage, 42, 'Hello', true).value();
+## See also
 
-// Object parameters with breadcrumbs
-const result = await new Try(updateUser, userData, options)
-  .breadcrumbs(['userId', 'email'])
-  .report('User update failed')
-  .value();
-```
-
-### Error Handling Strategies
-```typescript
-// 1. Throw on error
-const result = await new Try(riskyOperation).unwrap();
-
-// 2. Return undefined on error
-const result = await new Try(riskyOperation).value();
-
-// 3. Get error as value
-const error = await new Try(riskyOperation).error();
-
-// 4. Discriminated union result
-const result = await new Try(riskyOperation).result();
-if (result.success) {
-  console.log(result.value);
-} else {
-  console.log(result.error);
-}
-```
-
-### Breadcrumb Configuration
-```typescript
-// Extract keys from first object parameter
-.breadcrumbs(['userId', 'email'])
-
-// Transformer functions for any parameter types
-.breadcrumbs(
-  (id) => ({ userId: id }),
-  (data) => ({ hasEmail: !!data.email })
-)
-
-// Object syntax with parameter indices
-.breadcrumbs({
-  0: (url) => ({ endpoint: url }),
-  1: ['userId', 'email'],
-  2: (opts) => ({ optionCount: Object.keys(opts).length })
-})
-
-// Extractor objects for advanced control
-.breadcrumbs([
-  { param: 0, as: 'value' },
-  { param: 1, keys: ['id', 'name'] },
-  { param: 2, transform: (data) => ({ count: data.length }) }
-])
-```
-
-### Real-World Patterns
-```typescript
-// Service layer with comprehensive error handling
-class UserService {
-  async findById(id: string): Promise<User | null> {
-    return new Try(this.apiClient.get, `/users/${id}`)
-      .tag('service', 'user')
-      .tag('operation', 'findById')
-      .breadcrumbs([{ param: 0, as: 'value' }])
-      .report('Failed to find user by ID')
-      .value() ?? null;
-  }
-}
-
-// API client with automatic retry and error reporting
-class ApiClient {
-  async get<T>(endpoint: string): Promise<T | null> {
-    return new Try(this.makeRequest, 'GET', endpoint)
-      .tag('method', 'GET')
-      .breadcrumbs([
-        { param: 0, as: 'value' },
-        { param: 1, as: 'value' }
-      ])
-      .report(`Failed to GET ${endpoint}`)
-      .value();
-  }
-}
-```
-
-### Testing Patterns
-```typescript
-// Custom test reporter
-class TestReporter implements Reporter {
-  reports: Array<{ error: Error; config: ErrorReportConfig }> = [];
-
-  report(error: Error, config: ErrorReportConfig): void {
-    this.reports.push({ error, config });
-  }
-
-  // ... other methods
-}
-
-// Set up for testing
-Try.setDefaultReporter(new TestReporter());
-
-// Test your code
-await new Try(riskyFunction)
-  .report('Test error')
-  .value();
-
-// Verify error reporting
-expect(testReporter.reports).toHaveLength(1);
-```
-
-## Example Output
-
-When you run `comprehensive-examples.ts`, you'll see detailed console output showing:
-
-- ✅ Successful operations and their results
-- 📊 Error reports with breadcrumb data
-- 🍞 Breadcrumb extraction in action
-- 🧹 Cleanup operations
-- Performance metrics
-- Type safety demonstrations
-
-## Platform-Specific Usage
-
-The examples show how to import and use the library for different platforms:
-
-```typescript
-// Node.js
-import { Try } from '../src/node';
-
-// Browser
-import { Try } from '../src/browser';
-
-// Next.js
-import { Try } from '../src/nextjs';
-```
-
-## Next Steps
-
-1. **Run the examples** to see the library in action
-2. **Adapt the patterns** to your specific use cases
-3. **Create custom reporters** for your error tracking needs
-4. **Implement service layers** using the demonstrated patterns
-5. **Write tests** using the testing patterns shown
-
-## Contributing
-
-If you have additional example patterns that would be helpful, please contribute them to this directory following the established patterns and documentation style.
+- [../README.md](../README.md) — API tour and library overview
+- [../docs/GETTING-STARTED.md](../docs/GETTING-STARTED.md) — choosing the right entry point (`@power-rent/try-catch` vs `/node`, `/browser`, `/nextjs`)

--- a/examples/comprehensive-examples.ts
+++ b/examples/comprehensive-examples.ts
@@ -1,977 +1,361 @@
 /**
- * Comprehensive Examples for Try-Catch Library
+ * Comprehensive Examples — tour of the current `@power-rent/try-catch` API.
  *
- * This file demonstrates all key features and usage patterns of the try-catch library,
- * including basic usage, error handling strategies, breadcrumb patterns, platform-specific
- * implementations, real-world patterns, and advanced configuration.
+ * This file is type-checked via `npx tsc -p examples` and demonstrates every
+ * method currently on the `Try` class plus key reporter-related patterns.
  *
- * Run with: npx ts-node examples/comprehensive-examples.ts
+ * All imports use published package paths and every pattern shown
+ * matches the current `src/` behavior. The synthetic fixtures below
+ * (e.g. `fetchUser`) never perform real I/O.
+ *
+ * Behaviors referenced in this file:
+ *   - non-Error throws are normalized to `Error` with
+ *     `message === "Non-Error thrown (<typeof>)"` and `cause === original`.
+ *   - breadcrumbs record on every terminal method
+ *     (.value / .unwrap / .error / .result) — not only on .unwrap.
+ *
+ * Swap `NoopReporter` for `ConsoleReporter` (see ./custom-reporter.ts) to see
+ * reports printed to stdout; in production swap for a real Sentry/etc. reporter.
  */
+import {
+  Try,
+  NoopReporter,
+  type TryResult,
+  type Reporter,
+  type ErrorReportConfig,
+} from '@power-rent/try-catch';
 
-import { Try, Reporter, ErrorReportConfig, NoopReporter } from '../src/core';
+// Runtime-specific entry points are importable the same way. The selection of
+// the right entry point is a build-time/config-time concern — see
+// docs/GETTING-STARTED.md. These imports are type-only here to keep the file
+// runnable under any environment.
+import type { Try as NodeTry } from '@power-rent/try-catch/node';
+import type { Try as BrowserTry } from '@power-rent/try-catch/browser';
+import type { Try as NextjsTry } from '@power-rent/try-catch/nextjs';
 
-// =============================================================================
-// SECTION 1: BASIC USAGE PATTERNS
-// =============================================================================
+// Register the library default: produce no reports when this file runs.
+Try.setDefaultReporter(new NoopReporter());
 
-console.log('='.repeat(80));
-console.log('SECTION 1: BASIC USAGE PATTERNS');
-console.log('='.repeat(80));
+// === Section: Synthetic fixtures ===
+// Realistic-looking but fully local functions used across the examples.
 
-// Mock data types for examples
 interface User {
-  id: string;
-  name: string;
+  id: number;
   email: string;
-  age?: number;
-}
-
-interface UserData {
   name: string;
-  email: string;
-  age?: number;
 }
 
-interface CreateUserData extends UserData {
-  password: string;
-}
-
-interface UpdateOptions {
-  validateOnly?: boolean;
-  skipNotification?: boolean;
-}
-
-// Mock async functions that might fail
-async function fetchUser(id: string): Promise<User> {
-  await new Promise((resolve) => setTimeout(resolve, 100)); // Simulate network delay
-
-  if (id === 'invalid') {
-    throw new Error(`User not found: ${id}`);
+async function fetchUser(id: number): Promise<User> {
+  if (id <= 0) {
+    throw new Error(`invalid user id: ${id}`);
   }
+  return { id, email: `user${id}@example.com`, name: `User ${id}` };
+}
 
-  return {
-    id,
-    name: `User ${id}`,
-    email: `user${id}@example.com`,
-    age: Math.floor(Math.random() * 50) + 20,
-  };
+function parseIntStrict(input: string): number {
+  const n = Number(input);
+  if (!Number.isFinite(n)) {
+    throw new Error(`not a number: ${input}`);
+  }
+  return n;
 }
 
 async function updateUser(
-  userData: UserData,
-  options: UpdateOptions = {},
+  input: { userId: number; email: string },
+  options: { dryRun: boolean },
 ): Promise<User> {
-  await new Promise((resolve) => setTimeout(resolve, 50));
-
-  if (!userData.email.includes('@')) {
-    throw new Error('Invalid email format');
+  if (!options.dryRun && input.userId < 0) {
+    throw new Error('cannot persist negative user id');
   }
-
-  if (options.validateOnly) {
-    throw new Error('Validation only mode - no actual update');
-  }
-
-  return {
-    id: 'updated-user',
-    ...userData,
-  };
+  return { id: input.userId, email: input.email, name: `User ${input.userId}` };
 }
 
-function formatMessage(id: number, message: string, urgent: boolean): string {
-  if (id < 0) {
-    throw new Error('Invalid message ID');
-  }
-
-  const prefix = urgent ? '[URGENT]' : '[INFO]';
-  return `${prefix} #${id}: ${message}`;
+async function flaky(): Promise<number> {
+  throw new Error('flaky failure');
 }
 
-async function processData(input: string): Promise<string> {
-  if (input.length === 0) {
-    throw new Error('Empty input not allowed');
-  }
-  return input.toUpperCase();
-}
+// === Section: Sync basics ===
 
-// Basic usage demonstrations
-async function demonstrateBasicUsage() {
-  console.log('\n--- Basic Usage Patterns ---');
+export function syncBasics(): void {
+  // .value() returns T | undefined (or the configured default) and never throws.
+  const n1 = new Try(parseIntStrict, '42').value();
+  console.log('syncBasics value', n1); // 42
 
-  // 1. Simple async function with string parameter
-  console.log('\n1. Simple async function:');
-  const user = await new Try(fetchUser, 'user-123').value();
-  console.log('✅ Fetched user:', user?.name);
+  // .unwrap() throws on error, returns T on success.
+  const n2 = new Try(parseIntStrict, '7').unwrap();
+  console.log('syncBasics unwrap', n2); // 7
 
-  // 2. Function with multiple parameter types
-  console.log('\n2. Multiple parameter types:');
-  const message = await new Try(
-    formatMessage,
-    42,
-    'System ready',
-    true,
-  ).value();
-  console.log('✅ Formatted message:', message);
+  // .error() returns Error | undefined.
+  const err = new Try(parseIntStrict, 'not-a-number').error();
+  console.log('syncBasics error', err?.message); // "not a number: not-a-number"
 
-  // 3. Function with object parameters
-  console.log('\n3. Object parameters:');
-  const updatedUser = await new Try(
-    updateUser,
-    { name: 'John Doe', email: 'john@example.com' },
-    { validateOnly: false },
-  ).value();
-  console.log('✅ Updated user:', updatedUser?.name);
-
-  // 4. Handling errors gracefully
-  console.log('\n4. Error handling:');
-  const invalidUser = await new Try(fetchUser, 'invalid').value();
-  console.log('✅ Invalid user result (should be undefined):', invalidUser);
-}
-
-// =============================================================================
-// SECTION 2: ERROR HANDLING STRATEGIES
-// =============================================================================
-
-async function demonstrateErrorStrategies() {
-  console.log('\n--- Error Handling Strategies ---');
-
-  // Strategy 1: .unwrap() - Let errors bubble up
-  console.log('\n1. Unwrap Strategy (throws errors):');
-  try {
-    await new Try(fetchUser, 'invalid').unwrap();
-  } catch (error) {
-    console.log('✅ Caught error from unwrap():', (error as Error).message);
-  }
-
-  // Strategy 2: .value() - Return undefined on error
-  console.log('\n2. Value Strategy (returns undefined):');
-  const safeResult = await new Try(fetchUser, 'invalid').value();
-  console.log('✅ Safe result:', safeResult); // undefined
-
-  // Strategy 3: .error() - Get error as value
-  console.log('\n3. Error Strategy (error as value):');
-  const error = await new Try(fetchUser, 'invalid').error();
-  console.log('✅ Error object:', error?.message);
-
-  // Strategy 4: .result() - Discriminated union
-  console.log('\n4. Result Strategy (discriminated union):');
-  const result = await new Try(fetchUser, 'invalid').result();
-  if (result.success) {
-    console.log('✅ Success:', result.value.name);
+  // .result() returns a discriminated union — exhaustive pattern match.
+  const r: TryResult<number> = new Try(parseIntStrict, '99').result();
+  if (r.success) {
+    console.log('syncBasics result.value', r.value);
   } else {
-    console.log('✅ Error result:', result.error.message);
+    console.log('syncBasics result.error', r.error.message);
   }
+}
 
-  // Strategy 5: Default values
-  console.log('\n5. Default Values:');
-  const userWithDefault = await new Try(fetchUser, 'invalid')
+// === Section: Async basics ===
+
+export async function asyncBasics(): Promise<void> {
+  // For async functions, terminal methods return Promises.
+  const u1 = await new Try(fetchUser, 1).value(); // User | undefined
+  console.log('asyncBasics value', u1?.email);
+
+  const u2 = await new Try(fetchUser, 2).unwrap(); // throws on failure
+  console.log('asyncBasics unwrap', u2.email);
+
+  const err = await new Try(fetchUser, -1).error(); // Error | undefined
+  console.log('asyncBasics error', err?.message);
+
+  const r = await new Try(fetchUser, 3).result(); // TryResult<User>
+  console.log('asyncBasics result.success', r.success);
+
+  // `await new Try(asyncFn, ...)` is shorthand for `.value()`.
+  const u3 = await new Try(fetchUser, 4);
+  console.log('asyncBasics await shorthand', u3?.email);
+}
+
+// === Section: Fallback with .default() ===
+
+export async function fallbackWithDefault(): Promise<void> {
+  // .default() supplies the value used when the wrapped function fails.
+  const users = await new Try(fetchUser, -1)
     .default({
-      id: 'default',
-      name: 'Default User',
-      email: 'default@example.com',
-    })
+      id: 0,
+      email: 'anon@example.com',
+      name: 'Anonymous',
+    } satisfies User)
     .value();
-  console.log('✅ User with default:', userWithDefault?.name);
+  console.log('fallbackWithDefault value', users.email); // "anon@example.com"
+
+  // .default() only affects .value() — .unwrap() still throws.
+  const err = await new Try(fetchUser, -5)
+    .default({
+      id: 0,
+      email: 'anon@example.com',
+      name: 'Anonymous',
+    } satisfies User)
+    .error();
+  console.log('fallbackWithDefault error still surfaces', err?.message);
 }
 
-// =============================================================================
-// SECTION 3: BREADCRUMB PATTERNS
-// =============================================================================
+// === Section: Reporting + tags ===
 
-async function demonstrateBreadcrumbPatterns() {
-  console.log('\n--- Breadcrumb Patterns ---');
-
-  // Setup a test reporter to see breadcrumbs
-  class TestReporter implements Reporter {
-    report(error: Error, config: ErrorReportConfig): void {
-      console.log('📊 Error Report:', {
-        message: config.message,
-        error: error.message,
-        breadcrumbs: config.breadcrumbData,
-        tags: config.tags,
-      });
-    }
-
-    addBreadcrumbs(data: Record<string, unknown>, functionName?: string): void {
-      console.log('🍞 Breadcrumbs added:', { function: functionName, data });
-    }
-
-    createWrappedError(error: Error, message: string): Error {
-      return new Error(`${message}: ${error.message}`);
-    }
-  }
-
-  Try.setDefaultReporter(new TestReporter());
-
-  console.log('\n1. Simple key extraction:');
-  await new Try(
-    updateUser,
-    { name: 'John', email: 'john@example.com', age: 30 },
-    { validateOnly: true },
-  )
-    .breadcrumbs(['name', 'email'])
-    .report('User update failed')
+export async function reportingAndTags(): Promise<void> {
+  // .report() attaches a message used by the reporter on failure.
+  await new Try(flaky)
+    .report('flaky-op failed')
+    .tag('component', 'billing')
+    .tag('severity', 'high')
     .value();
 
-  console.log('\n2. Transformer function breadcrumb extraction:');
-  await new Try(formatMessage, 999, 'Test message', true)
+  // .tags() sets multiple tags in one call.
+  await new Try(flaky)
+    .report('flaky-op failed')
+    .tags({ component: 'billing', operation: 'charge', gateway: 'stripe' })
+    .value();
+
+  // `.unwrap()` with `.report()` wraps the original error with the given message.
+  try {
+    await new Try(flaky).report('billing op failed').unwrap();
+  } catch (e) {
+    const err = e as Error;
+    console.log('reporting wrapped message', err.message); // "billing op failed"
+    console.log('reporting original cause', (err.cause as Error)?.message);
+  }
+
+  // `Try.throwThroughErrorTypes` skips the wrap-step for listed error names.
+  class ValidationError extends Error {
+    override name = 'ValidationError';
+  }
+  Try.throwThroughErrorTypes(['ValidationError']);
+  try {
+    await new Try(async () => {
+      throw new ValidationError('bad input');
+    })
+      .report('this message is ignored for ValidationError')
+      .unwrap();
+  } catch (e) {
+    console.log('throwThrough', (e as Error).name); // "ValidationError"
+  }
+  Try.throwThroughErrorTypes([]); // reset
+}
+
+// === Section: Breadcrumbs variants ===
+
+export async function breadcrumbsVariants(): Promise<void> {
+  // 1) Keys from the first object parameter.
+  await new Try(updateUser, { userId: 1, email: 'a@b.com' }, { dryRun: true })
+    .breadcrumbs(['userId', 'email'])
+    .report('updateUser failed (keys)')
+    .value();
+
+  // 2) Variadic transformer functions — one per positional argument.
+  await new Try(updateUser, { userId: 2, email: 'c@d.com' }, { dryRun: false })
     .breadcrumbs(
-      (id: number) => ({ messageId: id }), // Transform first param
-      (msg: string) => ({ content: msg }), // Transform second param
-      (urgent: boolean) => ({ isUrgent: urgent }), // Transform third param
+      (input) => ({ userId: input.userId, emailLen: input.email.length }),
+      (opts) => ({ dryRun: opts.dryRun }),
     )
-    .report('Message formatting failed')
+    .report('updateUser failed (transformers)')
     .value();
 
-  console.log('\n3. Object syntax with transformers:');
-  await new Try(
-    updateUser,
-    { name: 'Jane', email: 'invalid-email', age: 25 },
-    { validateOnly: false, skipNotification: true },
-  )
+  // 3) Object syntax — parameter index as keys.
+  await new Try(updateUser, { userId: 3, email: 'e@f.com' }, { dryRun: true })
     .breadcrumbs({
-      0: ['name', 'age'], // Extract keys from first parameter
-      1: (opts: any) => ({
-        hasValidation: !!opts.validateOnly,
-        optionCount: Object.keys(opts).length,
-      }),
+      0: ['userId'],
+      1: (opts) => ({ dryRun: opts.dryRun }),
     })
-    .report('Complex update failed')
+    .report('updateUser failed (object-syntax)')
     .value();
 
-  console.log('\n4. Mixed extraction strategies using extractor objects:');
-  async function processOrder(
-    orderId: string,
-    customerData: { id: number; type: string },
-    urgent: boolean,
-  ) {
-    if (orderId === 'invalid') throw new Error('Invalid order');
-    return { orderId, processed: true };
-  }
-
-  await new Try(processOrder, 'invalid', { id: 123, type: 'premium' }, true)
+  // 4) Extractor objects — advanced positional control.
+  await new Try(updateUser, { userId: 4, email: 'g@h.com' }, { dryRun: false })
     .breadcrumbs([
-      { param: 0, as: 'value' }, // Extract orderId as value
-      { param: 1, keys: ['id', 'type'] }, // Extract keys from customerData
-      { param: 2, as: 'value' }, // Extract urgent as value
-    ])
-    .report('Order processing failed')
-    .value();
-
-  // Reset reporter
-  Try.setDefaultReporter(new NoopReporter());
-}
-
-// =============================================================================
-// SECTION 4: PLATFORM-SPECIFIC EXAMPLES
-// =============================================================================
-
-async function demonstratePlatformSpecific() {
-  console.log('\n--- Platform-Specific Examples ---');
-
-  // Note: These would use different imports in real usage
-  // import { Try } from '../src/node';      // For Node.js
-  // import { Try } from '../src/browser';   // For Browser
-  // import { Try } from '../src/nextjs';    // For Next.js
-
-  console.log('\n1. Node.js-style file operations:');
-  async function readConfig(configPath: string): Promise<any> {
-    if (configPath === 'missing.json') {
-      throw new Error('ENOENT: no such file or directory');
-    }
-    return { database: 'postgres://localhost' };
-  }
-
-  const config = await new Try(readConfig, 'app.json')
-    .tag('platform', 'nodejs')
-    .tag('operation', 'file-read')
-    .default({})
-    .value();
-  console.log('✅ Config loaded:', config);
-
-  console.log('\n2. Browser-style API calls:');
-  async function fetchFromAPI(
-    endpoint: string,
-    options: RequestInit = {},
-  ): Promise<any> {
-    if (endpoint.includes('error')) {
-      throw new Error('Network request failed');
-    }
-    return { data: 'API response', status: 200 };
-  }
-
-  const apiResult = await new Try(fetchFromAPI, '/api/users', { method: 'GET' })
-    .tag('platform', 'browser')
-    .tag('component', 'api-client')
-    .breadcrumbs([
-      { param: 0, as: 'value' },
+      { param: 0, keys: ['userId', 'email'] },
       {
         param: 1,
-        transform: (opts: any) => ({ method: opts.method || 'GET' }),
+        transform: (opts: { dryRun: boolean }) => ({
+          mode: opts.dryRun ? 'dry' : 'live',
+        }),
       },
     ])
-    .default(null)
+    .report('updateUser failed (extractors)')
     .value();
-  console.log('✅ API result:', apiResult);
-
-  console.log('\n3. Next.js-style server operations:');
-  async function getServerSideData(userId: string): Promise<any> {
-    if (userId === 'unauthorized') {
-      throw new Error('Access denied');
-    }
-    return { userData: `Data for ${userId}`, serverRendered: true };
-  }
-
-  const serverData = await new Try(getServerSideData, 'user-456')
-    .tag('platform', 'nextjs')
-    .tag('side', 'server')
-    .breadcrumbs([{ param: 0, as: 'value' }])
-    .default(null)
-    .value();
-  console.log('✅ Server data:', serverData);
 }
 
-// =============================================================================
-// SECTION 5: CLASS METHOD BINDING PATTERNS
-// =============================================================================
+// === Section: Breadcrumbs record on every terminal method ===
 
-class ApiClient {
-  private baseUrl: string;
+export async function breadcrumbsOnEveryTerminal(): Promise<void> {
+  // .value()
+  await new Try(fetchUser, -1).breadcrumbs((id) => ({ id })).value();
 
-  constructor(baseUrl: string) {
-    this.baseUrl = baseUrl;
-  }
-
-  async get<T>(
-    endpoint: string,
-    headers: Record<string, string> = {},
-  ): Promise<T> {
-    return this.makeRequest('GET', endpoint, undefined, headers);
-  }
-
-  async post<T>(
-    endpoint: string,
-    body: any,
-    headers: Record<string, string> = {},
-  ): Promise<T> {
-    return this.makeRequest('POST', endpoint, body, headers);
-  }
-
-  async put<T>(
-    endpoint: string,
-    body: any,
-    headers: Record<string, string> = {},
-  ): Promise<T> {
-    return this.makeRequest('PUT', endpoint, body, headers);
-  }
-
-  async delete<T>(
-    endpoint: string,
-    headers: Record<string, string> = {},
-  ): Promise<T> {
-    return this.makeRequest('DELETE', endpoint, undefined, headers);
-  }
-
-  private async makeRequest(
-    method: string,
-    endpoint: string,
-    body?: any,
-    headers: Record<string, string> = {},
-  ): Promise<any> {
-    // Simulate API call
-    await new Promise((resolve) => setTimeout(resolve, 50));
-
-    if (endpoint.includes('error')) {
-      throw new Error(
-        `HTTP ${method} request failed for ${this.baseUrl}${endpoint}`,
-      );
-    }
-
-    return {
-      data: `Response from ${method} ${this.baseUrl}${endpoint}`,
-      body,
-      timestamp: new Date().toISOString(),
-    };
-  }
-}
-
-class UserRepository {
-  private apiClient: ApiClient;
-  private boundGet: <T>(
-    endpoint: string,
-    headers?: Record<string, string>,
-  ) => Promise<T>;
-  private boundPost: <T>(
-    endpoint: string,
-    body: any,
-    headers?: Record<string, string>,
-  ) => Promise<T>;
-
-  constructor(apiClient: ApiClient) {
-    this.apiClient = apiClient;
-    // ✅ SOLUTION 4: Initialize bound methods in constructor
-    this.boundGet = this.apiClient.get.bind(this.apiClient);
-    this.boundPost = this.apiClient.post.bind(this.apiClient);
-  }
-
-  // ❌ WRONG: This will lose the `this` context binding
-  async findByIdWrong(id: string): Promise<User | null> {
-    // This approach will cause "Cannot read properties of undefined" errors
-    // because this.apiClient.get loses its `this` binding when passed as a reference
-    const result = await new Try(this.apiClient.get<User>, `/users/${id}`)
-      .tag('repository', 'user')
-      .tag('operation', 'findById')
-      .report('Failed to find user by ID')
-      .value();
-    return result ?? null;
-  }
-
-  // ✅ SOLUTION 1: Use arrow function wrapper
-  async findByIdWithWrapper(id: string): Promise<User | null> {
-    const result = await new Try(
-      (endpoint: string) => this.apiClient.get<User>(endpoint),
-      `/users/${id}`,
-    )
-      .tag('repository', 'user')
-      .tag('operation', 'findById')
-      .breadcrumbs([{ param: 0, as: 'value' }])
-      .report('Failed to find user by ID')
-      .value();
-    return result ?? null;
-  }
-
-  // ✅ SOLUTION 2: Use .bind() method
-  async findByIdWithBind(id: string): Promise<User | null> {
-    const boundGet = this.apiClient.get.bind(this.apiClient) as <T>(
-      endpoint: string,
-      headers?: Record<string, string>,
-    ) => Promise<T>;
-    const result = await new Try(boundGet<User>, `/users/${id}`)
-      .tag('repository', 'user')
-      .tag('operation', 'findById')
-      .breadcrumbs([{ param: 0, as: 'value' }])
-      .report('Failed to find user by ID')
-      .value();
-    return result ?? null;
-  }
-
-  // ✅ SOLUTION 3: Multi-parameter wrapper for complex cases
-  async createUser(userData: CreateUserData): Promise<User | null> {
-    const result = await new Try(
-      (
-        endpoint: string,
-        body: CreateUserData,
-        headers?: Record<string, string>,
-      ) => this.apiClient.post<User>(endpoint, body, headers),
-      '/users',
-      userData,
-      { 'Content-Type': 'application/json' },
-    )
-      .tag('repository', 'user')
-      .tag('operation', 'create')
-      .breadcrumbs({
-        0: (endpoint: any) => ({ endpoint }),
-        1: ['name', 'email'],
-        2: (headers: any) => ({
-          hasHeaders: !!headers,
-          headerCount: Object.keys(headers || {}).length,
-        }),
-      })
-      .report('Failed to create user')
-      .value();
-    return result ?? null;
-  }
-
-  // ✅ SOLUTION 4: Using bound methods stored as class properties (initialized in constructor)
-  async updateUserWithBoundMethods(
-    id: string,
-    updates: Partial<UserData>,
-  ): Promise<User | null> {
-    const result = await new Try(this.boundPost<User>, `/users/${id}`, updates)
-      .tag('repository', 'user')
-      .tag('operation', 'update')
-      .breadcrumbs([
-        { param: 0, as: 'value' },
-        {
-          param: 1,
-          transform: (updates: any) => ({
-            updateFields: Object.keys(updates),
-            fieldCount: Object.keys(updates).length,
-          }),
-        },
-      ])
-      .report(`Failed to update user ${id}`)
-      .value();
-    return result ?? null;
-  }
-}
-
-// Service class that properly handles method binding
-class UserService {
-  private userRepository: UserRepository;
-
-  constructor(userRepository: UserRepository) {
-    this.userRepository = userRepository;
-  }
-
-  // ✅ Proper delegation with error context
-  async findById(id: string): Promise<User | null> {
-    const result = await new Try(
-      (userId: string) => this.userRepository.findByIdWithWrapper(userId),
-      id,
-    )
-      .tag('service', 'user')
-      .tag('layer', 'business-logic')
-      .breadcrumbs([{ param: 0, as: 'value' }])
-      .report('User service failed to find user')
-      .value();
-    return result ?? null;
-  }
-
-  async createUser(userData: CreateUserData): Promise<User | null> {
-    // Add validation logic here
-    if (!userData.email.includes('@')) {
-      throw new Error('Invalid email format');
-    }
-
-    const result = await new Try(
-      (data: CreateUserData) => this.userRepository.createUser(data),
-      userData,
-    )
-      .tag('service', 'user')
-      .tag('layer', 'business-logic')
-      .breadcrumbs([{ param: 0, keys: ['name', 'email'] }])
-      .report('User service failed to create user')
-      .value();
-    return result ?? null;
-  }
-}
-
-async function demonstrateClassMethodBinding() {
-  console.log('\n--- Class Method Binding Patterns ---');
-
-  const apiClient = new ApiClient('https://api.example.com');
-  const userRepository = new UserRepository(apiClient);
-  const userService = new UserService(userRepository);
-
-  console.log('\n1. Testing arrow function wrapper approach:');
-  const user1 = await userRepository.findByIdWithWrapper('user-123');
-  console.log('✅ User found with wrapper:', user1);
-
-  console.log('\n2. Testing .bind() approach:');
-  const user2 = await userRepository.findByIdWithBind('user-456');
-  console.log('✅ User found with bind:', user2);
-
-  console.log('\n3. Testing multi-parameter wrapper:');
-  const newUser = await userRepository.createUser({
-    name: 'John Doe',
-    email: 'john@example.com',
-    password: 'secure123',
-  });
-  console.log('✅ User created with multi-param wrapper:', newUser);
-
-  console.log('\n4. Testing bound methods:');
-  const updatedUser = await userRepository.updateUserWithBoundMethods(
-    'user-789',
-    {
-      name: 'Jane Smith',
-      age: 30,
-    },
-  );
-  console.log('✅ User updated with bound methods:', updatedUser);
-
-  console.log('\n5. Testing service layer delegation:');
-  const serviceUser = await userService.findById('user-service-test');
-  console.log('✅ User found via service:', serviceUser);
-
-  console.log(
-    '\n6. Demonstrating the wrong approach (commented out to avoid errors):',
-  );
-  console.log('// ❌ This would fail:');
-  console.log(
-    "// await new Try(this.apiClient.post<User>, '/users', userData)",
-  );
-  console.log(
-    "// Error: Cannot read properties of undefined (reading 'makeRequest')",
-  );
-  console.log(
-    "\n✅ Key takeaway: Always wrap class methods to preserve 'this' context!",
-  );
-}
-
-// =============================================================================
-// SECTION 6: REAL-WORLD SERVICE PATTERNS
-// =============================================================================
-
-// Example of a properly implemented API client for real-world patterns
-class RealWorldApiClient {
-  private baseUrl: string;
-
-  constructor(baseUrl: string) {
-    this.baseUrl = baseUrl;
-  }
-
-  // ✅ Proper implementation using private method with correct binding
-  async get<T>(
-    endpoint: string,
-    headers: Record<string, string> = {},
-  ): Promise<T | null> {
-    const result = await new Try(
-      (method: string, ep: string, body: any, h: Record<string, string>) =>
-        this.makeRequest(method, ep, body, h),
-      'GET',
-      endpoint,
-      undefined,
-      headers,
-    )
-      .tag('method', 'GET')
-      .tag('client', 'api')
-      .breadcrumbs([
-        { param: 0, as: 'value' }, // httpMethod
-        { param: 1, as: 'value' }, // endpoint
-        {
-          param: 3,
-          transform: (h: any) => ({
-            headerCount: Object.keys(h).length,
-            hasAuth: !!h.authorization,
-          }),
-        },
-      ])
-      .report(`Failed to GET ${endpoint}`)
-      .value();
-    return result;
-  }
-
-  async post<T>(
-    endpoint: string,
-    body: any,
-    headers: Record<string, string> = {},
-  ): Promise<T | null> {
-    const result = await new Try(
-      (method: string, ep: string, b: any, h: Record<string, string>) =>
-        this.makeRequest(method, ep, b, h),
-      'POST',
-      endpoint,
-      body,
-      headers,
-    )
-      .tag('method', 'POST')
-      .tag('client', 'api')
-      .breadcrumbs({
-        0: (method: any) => ({ httpMethod: method }),
-        1: (endpoint: any) => ({ endpoint }),
-        2: (body: any) => ({ bodyType: typeof body, hasData: !!body }),
-        3: (headers: any) => ({ headerCount: Object.keys(headers).length }),
-      })
-      .report(`Failed to POST ${endpoint}`)
-      .value();
-    return result;
-  }
-
-  private async makeRequest(
-    method: string,
-    endpoint: string,
-    body?: any,
-    headers: Record<string, string> = {},
-  ): Promise<any> {
-    // Simulate API call
-    await new Promise((resolve) => setTimeout(resolve, 50));
-
-    if (endpoint.includes('error')) {
-      throw new Error(`HTTP ${method} request failed`);
-    }
-
-    return {
-      data: `Response from ${method} ${endpoint}`,
-      timestamp: new Date().toISOString(),
-    };
-  }
-}
-
-class RealWorldUserService {
-  private apiClient: RealWorldApiClient;
-
-  constructor(apiClient: RealWorldApiClient) {
-    this.apiClient = apiClient;
-  }
-
-  // ✅ Proper implementation using wrapper function
-  async findById(id: string): Promise<User | null> {
-    const result = await new Try(
-      (endpoint: string, headers?: Record<string, string>) =>
-        this.apiClient.get<User>(endpoint, headers),
-      `/users/${id}`,
-    )
-      .tag('service', 'user')
-      .tag('operation', 'findById')
-      .breadcrumbs([{ param: 0, as: 'value' }])
-      .report('Failed to find user by ID')
-      .value();
-    return result ?? null;
-  }
-
-  async create(userData: CreateUserData): Promise<User | null> {
-    const result = await new Try(
-      (
-        endpoint: string,
-        body: CreateUserData,
-        headers?: Record<string, string>,
-      ) => this.apiClient.post<User>(endpoint, body, headers),
-      '/users',
-      userData,
-    )
-      .tag('service', 'user')
-      .tag('operation', 'create')
-      .breadcrumbs({
-        0: (endpoint: any) => ({ endpoint }),
-        1: ['name', 'email'],
-      })
-      .report('Failed to create user')
-      .value();
-    return result ?? null;
-  }
-
-  async update(id: string, updates: Partial<UserData>): Promise<User | null> {
-    const result = await new Try(
-      (endpoint: string, body: Partial<UserData>) =>
-        this.apiClient.post<User>(endpoint, body),
-      `/users/${id}`,
-      updates,
-    )
-      .tag('service', 'user')
-      .tag('operation', 'update')
-      .breadcrumbs([
-        { param: 0, as: 'value' }, // endpoint with userId
-        {
-          param: 1,
-          transform: (updates: any) => ({
-            updateFields: Object.keys(updates),
-            fieldCount: Object.keys(updates).length,
-          }),
-        },
-      ])
-      .report(`Failed to update user ${id}`)
-      .value();
-    return result ?? null;
-  }
-}
-
-async function demonstrateRealWorldPatterns() {
-  console.log('\n--- Real-World Service Patterns ---');
-
-  const apiClient = new RealWorldApiClient('https://api.example.com');
-  const userService = new RealWorldUserService(apiClient);
-
-  console.log('\n1. API Client with error handling:');
-  const userData = await apiClient.get('/users/123');
-  console.log('✅ API Client result:', userData);
-
-  console.log('\n2. Service layer with comprehensive error handling:');
-  const user = await userService.findById('user-789');
-  console.log('✅ User service result:', user);
-
-  console.log('\n3. Create operation with validation:');
-  const newUser = await userService.create({
-    name: 'Alice Johnson',
-    email: 'alice@example.com',
-    password: 'secure123',
-  });
-  console.log('✅ Created user:', newUser);
-
-  console.log('\n4. Update operation with partial data:');
-  const updatedUser = await userService.update('user-456', {
-    name: 'Alice Smith',
-    age: 28,
-  });
-  console.log('✅ Updated user:', updatedUser);
-}
-
-// =============================================================================
-// SECTION 7: ADVANCED CONFIGURATION
-// =============================================================================
-
-async function demonstrateAdvancedConfiguration() {
-  console.log('\n--- Advanced Configuration ---');
-
-  // 1. Debug logging
-  console.log('\n1. Debug logging:');
-  const debugResult = await new Try(processData, '')
-    .debug(true) // Enable debug logging
-    .tag('feature', 'debug')
-    .report('Processing failed with debug enabled')
-    .value();
-  console.log('✅ Debug result:', debugResult);
-
-  // 2. Finally callbacks for cleanup
-  console.log('\n2. Finally callbacks:');
-  let cleanupCalled = false;
-  const resultWithCleanup = await new Try(async () => {
-    await new Promise((resolve) => setTimeout(resolve, 50));
-    return 'Operation completed';
-  })
-    .finally(() => {
-      cleanupCalled = true;
-      console.log('🧹 Cleanup executed');
-    })
-    .value();
-  console.log('✅ Result with cleanup:', resultWithCleanup);
-  console.log('✅ Cleanup was called:', cleanupCalled);
-
-  // 3. Error type filtering
-  console.log('\n3. Error type filtering:');
-  class ValidationError extends Error {
-    name = 'ValidationError';
-  }
-
-  class AuthError extends Error {
-    name = 'AuthError';
-  }
-
-  // Configure certain errors to be thrown through without wrapping
-  Try.throwThroughErrorTypes(['ValidationError', 'AuthError']);
-
-  async function validateInput(input: string): Promise<string> {
-    if (input.length < 3) {
-      throw new ValidationError('Input too short');
-    }
-    return input;
-  }
-
+  // .unwrap() — catches to keep example runnable
   try {
-    await new Try(validateInput, 'ab')
-      .report('Custom validation message')
-      .unwrap();
-  } catch (error: any) {
-    console.log('✅ Error type preserved:', error.constructor.name);
-    console.log('✅ Error message preserved:', error.message);
+    await new Try(fetchUser, -1).breadcrumbs((id) => ({ id })).unwrap();
+  } catch {
+    /* breadcrumbs were recorded before the throw */
   }
 
-  // 4. Complex tagging strategies
-  console.log('\n4. Complex tagging:');
-  const environment = 'development';
-  const version = '1.2.3';
+  // .error()
+  await new Try(fetchUser, -1).breadcrumbs((id) => ({ id })).error();
 
-  await new Try(fetchUser, 'test-user')
-    .tags({
-      environment,
-      version,
-      component: 'user-fetcher',
-      correlationId: Math.random().toString(36),
+  // .result()
+  await new Try(fetchUser, -1).breadcrumbs((id) => ({ id })).result();
+}
+
+// === Section: Non-Error normalization ===
+
+export async function nonErrorThrows(): Promise<void> {
+  // Throwing a string is normalized to an `Error` with:
+  //   - message === "Non-Error thrown (string)"
+  //   - cause   === "boom"
+  const r = await new Try(async () => {
+    throw 'boom';
+  }).result();
+
+  if (!r.success) {
+    console.log('nonError message', r.error.message); // "Non-Error thrown (string)"
+    console.log('nonError cause', r.error.cause); // "boom"
+  }
+
+  // Same contract for objects, numbers, null, undefined.
+  const r2 = new Try(() => {
+    throw { code: 500 };
+  }).result();
+  if (!r2.success) {
+    console.log('nonError object', r2.error.message); // "Non-Error thrown (object)"
+  }
+}
+
+// === Section: finally + debug ===
+
+export async function finallyAndDebug(): Promise<void> {
+  let ran = false;
+
+  // .finally() runs once after the wrapped function settles (success or failure),
+  // before the error is re-thrown by .unwrap().
+  await new Try(fetchUser, 5)
+    .finally(() => {
+      ran = true;
     })
-    .tag('timestamp', new Date().toISOString())
-    .debug(environment === 'development')
-    .report('User fetch failed')
     .value();
+  console.log('finallyAndDebug finally-ran', ran);
 
-  console.log('✅ Complex tagging demonstrated');
+  // .debug() opts in to console.error on failure — libraries should not log
+  // by default, so this is explicit and reversible.
+  await new Try(fetchUser, -1).debug().value();
+  await new Try(fetchUser, -1).debug(false).value();
+  await new Try(fetchUser, -1)
+    .debug(process.env.NODE_ENV === 'development')
+    .value();
 }
 
-// =============================================================================
-// SECTION 8: TESTING PATTERNS
-// =============================================================================
+// === Section: Reporter interface recap ===
+// See ./custom-reporter.ts for the canonical minimal implementation.
+// Here we show the shape used to type a reporter parameter.
 
-class TestReporter implements Reporter {
-  public reports: Array<{ error: Error; config: ErrorReportConfig }> = [];
-  public breadcrumbs: Array<{
-    data: Record<string, unknown>;
-    functionName?: string;
-  }> = [];
-
-  report(error: Error, config: ErrorReportConfig): void {
-    this.reports.push({ error, config });
-  }
-
-  addBreadcrumbs(data: Record<string, unknown>, functionName?: string): void {
-    this.breadcrumbs.push({ data, functionName });
-  }
-
-  createWrappedError(error: Error, message: string): Error {
-    const wrapped = new Error(`${message}: ${error.message}`);
-    wrapped.cause = error;
-    return wrapped;
-  }
-
-  reset(): void {
-    this.reports = [];
-    this.breadcrumbs = [];
-  }
-}
-
-async function demonstrateTestingPatterns() {
-  console.log('\n--- Testing Patterns ---');
-
-  const testReporter = new TestReporter();
-  Try.setDefaultReporter(testReporter);
-
-  console.log('\n1. Testing error reporting:');
-  await new Try(fetchUser, 'invalid')
-    .tag('test', 'error-reporting')
-    .breadcrumbs([{ param: 0, as: 'value' }])
-    .report('Test error report')
-    .value();
-
-  console.log('✅ Error reports captured:', testReporter.reports.length);
-  console.log('✅ Breadcrumbs captured:', testReporter.breadcrumbs.length);
-
-  console.log('\n2. Testing breadcrumb extraction:');
-  testReporter.reset();
-
-  await new Try(
-    updateUser,
-    { name: 'Test User', email: 'test@example.com' },
-    { validateOnly: true },
-  )
-    .breadcrumbs(['name', 'email'])
-    .report('Test breadcrumb extraction')
-    .value();
-
-  const lastReport = testReporter.reports[0];
-  console.log('✅ Extracted breadcrumbs:', lastReport?.config.breadcrumbData);
-
-  console.log('\n3. Performance testing pattern:');
-  const startTime = Date.now();
-  const iterations = 100;
-
-  for (let i = 0; i < iterations; i++) {
-    await new Try(processData, `test-${i}`).value();
-  }
-
-  const endTime = Date.now();
-  const avgTime = (endTime - startTime) / iterations;
-  console.log(`✅ Average execution time: ${avgTime.toFixed(2)}ms per call`);
-
-  // Reset to no-op reporter
+export function reporterInterfaceRecap(): void {
+  // A Reporter must implement all three methods:
+  const myReporter: Reporter = {
+    report(_error: Error, _config: ErrorReportConfig): void {
+      /* forward to your backend */
+    },
+    addBreadcrumbs(
+      _data: Record<string, unknown>,
+      _functionName?: string,
+    ): void {
+      /* attach context */
+    },
+    createWrappedError(error: Error, message: string): Error {
+      const wrapped = new Error(message);
+      wrapped.cause = error;
+      wrapped.stack = error.stack;
+      return wrapped;
+    },
+  };
+  // Register at app startup to change what all Try instances report to.
+  Try.setDefaultReporter(myReporter);
+  // Reset back to the no-op for the rest of this file.
   Try.setDefaultReporter(new NoopReporter());
 }
 
-// =============================================================================
-// MAIN EXECUTION
-// =============================================================================
+// === Section: Entry-point selection (type-only) ===
+// Pick the entry point that matches your runtime; see docs/GETTING-STARTED.md.
+//
+//   import { Try } from '@power-rent/try-catch';         // framework-agnostic, NoopReporter default
+//   import { Try } from '@power-rent/try-catch/node';    // NodeReporter default
+//   import { Try } from '@power-rent/try-catch/browser'; // BrowserReporter default
+//   import { Try } from '@power-rent/try-catch/nextjs';  // SentryReporter default
+//
+// The four classes share the same public surface, so code written against the
+// core `Try` continues to work if you switch entry points.
 
-async function runComprehensiveExamples() {
-  console.log('🚀 Starting Try-Catch Library Comprehensive Examples\n');
+export type EntryPointClasses = {
+  node: typeof NodeTry;
+  browser: typeof BrowserTry;
+  nextjs: typeof NextjsTry;
+};
 
-  try {
-    await demonstrateBasicUsage();
-    await demonstrateErrorStrategies();
-    await demonstrateBreadcrumbPatterns();
-    await demonstratePlatformSpecific();
-    await demonstrateClassMethodBinding();
-    await demonstrateRealWorldPatterns();
-    await demonstrateAdvancedConfiguration();
-    await demonstrateTestingPatterns();
+// === Section: Runner ===
+// Calling this function drives the whole tour; executing the file directly
+// (via e.g. `tsx`) will run it. Type-checking alone does not invoke it.
 
-    console.log('\n' + '='.repeat(80));
-    console.log('✅ ALL EXAMPLES COMPLETED SUCCESSFULLY');
-    console.log('='.repeat(80));
-  } catch (error) {
-    console.error('\n❌ Example execution failed:', error);
-    process.exit(1);
-  }
+export async function runAll(): Promise<void> {
+  syncBasics();
+  await asyncBasics();
+  await fallbackWithDefault();
+  await reportingAndTags();
+  await breadcrumbsVariants();
+  await breadcrumbsOnEveryTerminal();
+  await nonErrorThrows();
+  await finallyAndDebug();
+  reporterInterfaceRecap();
 }
 
-// Export for testing or run directly
-if (require.main === module) {
-  runComprehensiveExamples();
-}
-
-export { runComprehensiveExamples, ApiClient, UserService, TestReporter };
+// Execute when run directly. Commented out by default so importing this module
+// in a test context does not cause side effects. Uncomment to run:
+// void runAll();

--- a/examples/custom-reporter.ts
+++ b/examples/custom-reporter.ts
@@ -1,70 +1,59 @@
-import { Try, Reporter, ErrorReportConfig, NoopReporter } from '../src/core';
-
 /**
- * Example custom reporter that logs to console instead of Sentry
+ * Custom Reporter Example
+ *
+ * Demonstrates the current three-method `Reporter` interface from
+ * `@power-rent/try-catch`:
+ *   - `report(error, config)`   — send the error to your tracking service
+ *   - `addBreadcrumbs(data, fn)` — attach breadcrumb context
+ *   - `createWrappedError(error, message)` — build the wrapped error thrown by `.unwrap()`
+ *
+ * Every adapter shipped with this library (`src/adapters/node`, `src/adapters/browser`,
+ * `src/nextjs/SentryReporter`) implements exactly this contract. A custom reporter
+ * for any other backend (Datadog, Honeycomb, console, in-memory test collector, …)
+ * follows the same shape.
  */
+import {
+  Try,
+  NoopReporter,
+  type Reporter,
+  type ErrorReportConfig,
+} from '@power-rent/try-catch';
+
+// === ConsoleReporter: a minimal Reporter that writes to stdout/stderr ===
+
 class ConsoleReporter implements Reporter {
   report(error: Error, config: ErrorReportConfig): void {
-    console.error('Error Report:', {
-      message: config.message || error.message,
-      error: error.name,
-      stack: error.stack,
+    console.error('[report]', {
+      message: config.message ?? error.message,
+      name: error.name,
       tags: config.tags,
-      functionName: config.functionName,
-      breadcrumbs: config.breadcrumbData,
+      stack: error.stack,
     });
   }
 
   addBreadcrumbs(data: Record<string, unknown>, functionName?: string): void {
-    console.log('Breadcrumbs:', {
-      function: functionName,
+    console.log('[breadcrumbs]', {
+      functionName: functionName ?? 'anonymous',
       data,
     });
   }
 
   createWrappedError(error: Error, message: string): Error {
-    const wrappedError = new Error(`${message}: ${error.message}`);
-    wrappedError.cause = error;
-    wrappedError.stack = error.stack;
-    return wrappedError;
+    const wrapped = new Error(message);
+    wrapped.cause = error;
+    wrapped.stack = error.stack;
+    return wrapped;
   }
 }
 
-/**
- * Example showing how to use different reporters
- */
-async function demonstrateReporters() {
-  // Example 1: Using NoopReporter (no reporting)
-  Try.setDefaultReporter(new NoopReporter());
+// === Baseline: NoopReporter ===
+// NoopReporter is the library default — it never sends anything, so tests and
+// examples can run with no side effects. Swap it out for a real reporter in
+// production code:
+Try.setDefaultReporter(new NoopReporter());
 
-  const result1 = await new Try(() => {
-    throw new Error('Test error 1');
-  })
-    .report("This error won't be reported anywhere")
-    .value();
+// === Swap-in: register the custom reporter ===
+// A single call replaces the default reporter for all subsequent Try instances.
+Try.setDefaultReporter(new ConsoleReporter());
 
-  console.log('Result 1 (NoopReporter):', result1); // undefined
-
-  // Example 2: Using ConsoleReporter (logs to console)
-  Try.setDefaultReporter(new ConsoleReporter());
-
-  const result2 = await new Try(() => {
-    throw new Error('Test error 2');
-  })
-    .report('This error will be logged to console')
-    .tag('component', 'demo')
-    .value();
-
-  console.log('Result 2 (ConsoleReporter):', result2); // undefined
-
-  // Example 3: Success case
-  const result3 = await new Try(() => {
-    return 'Success!';
-  })
-    .report("This won't be called since there's no error")
-    .value();
-
-  console.log('Result 3 (Success):', result3); // "Success!"
-}
-
-demonstrateReporters();
+export { ConsoleReporter };

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "moduleResolution": "node",
+    "baseUrl": ".",
+    "paths": {
+      "@power-rent/try-catch": ["../src/index.ts"],
+      "@power-rent/try-catch/*": ["../src/*/index.ts"]
+    }
+  },
+  "include": ["./*.ts"],
+  "exclude": ["../node_modules"]
+}

--- a/src/__tests__/docs/README.md
+++ b/src/__tests__/docs/README.md
@@ -1,0 +1,77 @@
+# Doctest Harness
+
+This directory contains the Vitest-based doctest harness that executes
+fenced code snippets embedded in the project's user-facing docs, so CI
+fails the moment a snippet stops matching real behavior.
+
+## Marker Convention
+
+Only fenced blocks tagged with the doctest marker are extracted and run:
+
+````markdown
+```ts doctest
+import { Try } from '@power-rent/try-catch';
+const ok = await new Try(() => 42).value();
+if (ok !== 42) throw new Error('doctest failed');
+```
+````
+
+Rules:
+
+- The info string must start with `ts` or `typescript`.
+- The token `doctest` must appear (whitespace-separated) after the language.
+- `` ```ts `` without `doctest` is skipped (use it for pedagogical or
+  illustrative code that should not execute).
+- `` ```bash ``, `` ```json ``, and any other language are always skipped.
+- An unterminated tagged fence fails the harness loudly.
+
+## Execution Contract
+
+Every tagged snippet runs inside the vitest suite `doctest.test.ts`:
+
+- **Reporter:** `Try.setDefaultReporter(new NoopReporter())` before each
+  snippet; prior reporter restored after.
+- **Sentry:** `@sentry/node`, `@sentry/browser`, `@sentry/nextjs` are
+  `vi.mock`-ed at module scope — no real Sentry traffic.
+- **Imports:** snippets must use the package names
+  (`@power-rent/try-catch`, `@power-rent/try-catch/node`,
+  `@power-rent/try-catch/browser`, `@power-rent/try-catch/nextjs`).
+  The vitest alias config wires these to local `src/` so snippets stay
+  copy-pasteable for users while still exercising real code.
+- **Assertions:** snippets self-assert with plain `if (...) throw new Error(...)`;
+  keep them small and independent.
+
+## Tracked Doc Surface
+
+The suite scans, in order:
+
+1. `README.md` at the repo root.
+2. Every `docs/*.md` file (alphabetical).
+3. Every `*.md` under `__fixtures__/` (seeded snippets used during
+   harness bring-up and regression testing).
+
+If **zero** tagged snippets are discovered across the entire surface,
+the suite fails with a clear error. There is no silent-pass skip branch.
+
+## Adding a Snippet
+
+1. Pick the file (usually `README.md` or one of `docs/*.md`).
+2. Open a fenced block with `` ```ts doctest ``.
+3. Import from the public package names only — no `../../src` paths.
+4. Self-assert the behavior you're demonstrating.
+5. Run `npm test` — the snippet is now enforced.
+
+## Temporarily Skipping a Snippet
+
+Remove the `doctest` token from the info string (leave `` ```ts `` in
+place). The block will still render in Markdown but will no longer be
+executed. Prefer this over deleting the block.
+
+## Files
+
+| File | Purpose |
+| ---- | ------- |
+| `doctest-extract.ts` | Marker-based fenced-block extractor (reusable). |
+| `doctest-extract.test.ts` | Unit tests for the extractor. |
+| `doctest.test.ts` | The suite that runs every discovered snippet. |
+| `__fixtures__/*.md` | Seed + regression snippets. |

--- a/src/__tests__/docs/__fixtures__/seed-snippet.md
+++ b/src/__tests__/docs/__fixtures__/seed-snippet.md
@@ -1,0 +1,17 @@
+# Seed Doctest Fixture
+
+This fixture exists solely to prove the doctest pipeline end-to-end during
+Wave 1 before real `README.md` / `docs/*.md` snippets carry the marker.
+
+Do not delete it until Wave 2 has tagged at least one real doc snippet —
+the harness fails with "no snippets found" if zero tagged blocks are
+discovered across the entire tracked surface.
+
+```ts doctest
+import { Try } from '@power-rent/try-catch';
+
+const value = await new Try(() => 40 + 2).value();
+if (value !== 42) {
+  throw new Error(`seed snippet expected 42, got ${String(value)}`);
+}
+```

--- a/src/__tests__/docs/doctest-extract.test.ts
+++ b/src/__tests__/docs/doctest-extract.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import { extractDoctests } from './doctest-extract';
+
+describe('extractDoctests', () => {
+  it('extracts a single tagged ```ts doctest``` fenced block', () => {
+    const source = [
+      '# Title',
+      '',
+      '```ts doctest',
+      'const x = 1;',
+      'console.log(x);',
+      '```',
+      '',
+      'Trailing prose.',
+    ].join('\n');
+
+    const blocks = extractDoctests(source);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].code).toBe('const x = 1;\nconsole.log(x);');
+    expect(blocks[0].index).toBe(0);
+    expect(blocks[0].startLine).toBe(3);
+  });
+
+  it('accepts the typescript alias in the info string', () => {
+    const source = ['```typescript doctest', 'const y = 2;', '```'].join('\n');
+
+    const blocks = extractDoctests(source);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].code).toBe('const y = 2;');
+  });
+
+  it('skips ts blocks without the doctest marker', () => {
+    const source = ['```ts', 'const ignored = true;', '```'].join('\n');
+
+    expect(extractDoctests(source)).toHaveLength(0);
+  });
+
+  it('skips typescript blocks without the doctest marker', () => {
+    const source = ['```typescript', 'const ignored = true;', '```'].join('\n');
+
+    expect(extractDoctests(source)).toHaveLength(0);
+  });
+
+  it('skips bash fenced blocks regardless of tokens', () => {
+    const source = [
+      '```bash',
+      'npm install @power-rent/try-catch',
+      '```',
+      '',
+      '```bash doctest',
+      'echo "still not executed"',
+      '```',
+    ].join('\n');
+
+    expect(extractDoctests(source)).toHaveLength(0);
+  });
+
+  it('extracts multiple tagged blocks with correct index + startLine metadata', () => {
+    const source = [
+      '```ts doctest',
+      'const a = 1;',
+      '```',
+      '',
+      'Prose between.',
+      '',
+      '```ts doctest',
+      'const b = 2;',
+      'const c = 3;',
+      '```',
+    ].join('\n');
+
+    const blocks = extractDoctests(source);
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0].code).toBe('const a = 1;');
+    expect(blocks[0].startLine).toBe(1);
+    expect(blocks[0].index).toBe(0);
+    expect(blocks[1].code).toBe('const b = 2;\nconst c = 3;');
+    expect(blocks[1].startLine).toBe(7);
+    expect(blocks[1].index).toBe(1);
+  });
+
+  it('throws a descriptive error on an unterminated fenced block', () => {
+    const source = ['```ts doctest', 'const oops = "no close fence";'].join(
+      '\n',
+    );
+
+    expect(() => extractDoctests(source)).toThrow(/unterminated/i);
+  });
+
+  it('throws a descriptive error on an unterminated untagged fenced block', () => {
+    const source = ['```bash', 'echo "no close fence"'].join('\n');
+
+    expect(() => extractDoctests(source)).toThrow(/unterminated/i);
+  });
+
+  it('ignores the doctest marker when the first token is neither ts nor typescript', () => {
+    const source = ['```js doctest', 'const x = 1;', '```'].join('\n');
+
+    expect(extractDoctests(source)).toHaveLength(0);
+  });
+
+  it('requires doctest to be a whitespace-separated token (not a substring)', () => {
+    const source = ['```ts notdoctestly', 'const x = 1;', '```'].join('\n');
+
+    expect(extractDoctests(source)).toHaveLength(0);
+  });
+});

--- a/src/__tests__/docs/doctest-extract.ts
+++ b/src/__tests__/docs/doctest-extract.ts
@@ -1,0 +1,85 @@
+/**
+ * Doctest extractor — the marker-based fenced-block reader for the doctest harness.
+ *
+ * The vitest suite executes tagged snippets from README + docs/*.md. The
+ * tagging convention is ```ts doctest``` — info-string must start with `ts`
+ * or `typescript` AND contain `doctest` as a whitespace-separated token. Any
+ * other fenced block is skipped. The extractor returns raw code; the harness
+ * wires imports to local src via vitest aliases rather than rewriting snippets.
+ *
+ * Kept intentionally small (no markdown parser dependency). Walks lines,
+ * detects fence open/close, accumulates body for matching blocks.
+ */
+
+export interface DoctestBlock {
+  /** Raw snippet body (no trailing newline). */
+  readonly code: string;
+  /** Zero-based index among all extracted (tagged) blocks in the source. */
+  readonly index: number;
+  /** 1-based line number of the opening fence within the source. */
+  readonly startLine: number;
+}
+
+const FENCE_OPEN = /^```(\S+)(?:\s+(.*))?$/;
+const FENCE_CLOSE = /^```\s*$/;
+
+/**
+ * Extract tagged doctest snippets from a Markdown source string.
+ *
+ * Rules:
+ *   - Opening fence info string must begin with `ts` or `typescript`.
+ *   - Remaining tokens (whitespace-separated) must include `doctest`.
+ *   - Everything else (including ```ts without doctest, ```bash, prose) is skipped.
+ *   - Unterminated tagged fences throw — silent truncation would mask dropped
+ *     docs coverage.
+ */
+export function extractDoctests(source: string): DoctestBlock[] {
+  const lines = source.split(/\r?\n/);
+  const blocks: DoctestBlock[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+    const match = FENCE_OPEN.exec(line);
+
+    if (!match) {
+      i += 1;
+      continue;
+    }
+
+    const lang = match[1];
+    const rest = match[2] || '';
+    const tagged = isDoctestFence(lang, rest);
+    const openLine = i + 1; // 1-based
+
+    // Walk to the close fence regardless of whether we're keeping this block,
+    // so nested "```" tokens in untagged blocks don't confuse the scanner.
+    const bodyStart = i + 1;
+    let j = bodyStart;
+    while (j < lines.length && !FENCE_CLOSE.test(lines[j])) {
+      j += 1;
+    }
+
+    if (j >= lines.length) {
+      const kind = tagged ? 'doctest fence' : 'fence';
+      throw new Error(
+        `extractDoctests: unterminated ${kind} opened at line ${openLine}`,
+      );
+    }
+
+    if (tagged) {
+      const code = lines.slice(bodyStart, j).join('\n');
+      blocks.push({ code, index: blocks.length, startLine: openLine });
+    }
+
+    i = j + 1;
+  }
+
+  return blocks;
+}
+
+function isDoctestFence(lang: string, rest: string): boolean {
+  if (lang !== 'ts' && lang !== 'typescript') return false;
+  const tokens = rest.trim().split(/\s+/).filter(Boolean);
+  return tokens.includes('doctest');
+}

--- a/src/__tests__/docs/doctest.test.ts
+++ b/src/__tests__/docs/doctest.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Doctest suite — executes every tagged fenced snippet in README.md,
+ * docs/*.md, and __fixtures__/*.md under a Noop reporter with all
+ * @sentry/* packages mocked.
+ *
+ * Zero-snippet policy: if no tagged snippet is found across the entire
+ * tracked doc surface, the suite fails.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  beforeAll,
+  afterAll,
+} from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+// mock Sentry entry points so snippets never hit real Sentry.
+vi.mock('@sentry/node', () => ({
+  captureException: vi.fn(),
+  addBreadcrumb: vi.fn(),
+}));
+vi.mock('@sentry/browser', () => ({
+  captureException: vi.fn(),
+  addBreadcrumb: vi.fn(),
+}));
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+  addBreadcrumb: vi.fn(),
+}));
+
+// Import Try + NoopReporter via a relative path so `tsc --noEmit` succeeds
+// without adding `paths` to tsconfig.json (the plan intentionally keeps the
+// package-name alias test-only). Runtime verification that the package-name
+// alias works still happens in the smoke test below via dynamic import.
+import { Try, NoopReporter } from '../../core';
+
+import { extractDoctests, type DoctestBlock } from './doctest-extract';
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const DOCS_DIR = path.join(REPO_ROOT, 'docs');
+const FIXTURES_DIR = path.join(__dirname, '__fixtures__');
+const TEMP_DIR = path.join(REPO_ROOT, 'node_modules', '.doctest');
+
+interface DiscoveredFile {
+  readonly absPath: string;
+  readonly relPath: string;
+  readonly blocks: readonly DoctestBlock[];
+}
+
+function discoverFiles(): DiscoveredFile[] {
+  const paths: string[] = [];
+
+  // README.md at repo root.
+  const readme = path.join(REPO_ROOT, 'README.md');
+  if (fs.existsSync(readme)) paths.push(readme);
+
+  // docs/*.md (tolerate missing directory).
+  if (fs.existsSync(DOCS_DIR) && fs.statSync(DOCS_DIR).isDirectory()) {
+    for (const name of fs.readdirSync(DOCS_DIR).sort()) {
+      if (name.endsWith('.md')) paths.push(path.join(DOCS_DIR, name));
+    }
+  }
+
+  // __fixtures__/*.md.
+  if (fs.existsSync(FIXTURES_DIR)) {
+    for (const name of fs.readdirSync(FIXTURES_DIR).sort()) {
+      if (name.endsWith('.md')) paths.push(path.join(FIXTURES_DIR, name));
+    }
+  }
+
+  return paths.map((absPath) => {
+    const relPath = path.relative(REPO_ROOT, absPath);
+    const source = fs.readFileSync(absPath, 'utf8');
+    const blocks = extractDoctests(source);
+    return { absPath, relPath, blocks };
+  });
+}
+
+const files = discoverFiles();
+const totalBlocks = files.reduce((n, f) => n + f.blocks.length, 0);
+
+describe('doctest harness', () => {
+  it('configures vitest aliases for @power-rent/try-catch', async () => {
+    // Verify the vitest alias config is wired so snippets can import the
+    // package by name. We assert on the config rather than via a dynamic
+    // import so we don't accidentally hit `dist/` via Node resolution.
+    const viteConfigModule = (await import('../../../vite.config')) as {
+      default: {
+        resolve?: { alias?: Array<{ find: unknown; replacement: string }> };
+      };
+    };
+    const aliases = viteConfigModule.default.resolve?.alias ?? [];
+    const findStrings = aliases.map((a) => String(a.find));
+    expect(findStrings).toContain('@power-rent/try-catch');
+    expect(findStrings).toContain('@power-rent/try-catch/node');
+    expect(findStrings).toContain('@power-rent/try-catch/browser');
+    expect(findStrings).toContain('@power-rent/try-catch/nextjs');
+    // Replacements must point into src/, not dist/.
+    for (const a of aliases) {
+      expect(a.replacement).toMatch(/\/src\//);
+      expect(a.replacement).not.toMatch(/\/dist\//);
+    }
+  });
+
+  it('discovers at least one tagged snippet across the tracked surface', () => {
+    if (totalBlocks === 0) {
+      throw new Error(
+        'No doctest snippets found — the harness requires at least one tagged snippet. ' +
+          'Expected coverage: README.md + docs/*.md + src/__tests__/docs/__fixtures__/*.md.',
+      );
+    }
+    expect(totalBlocks).toBeGreaterThan(0);
+  });
+});
+
+let priorReporter: ReturnType<typeof Try.getDefaultReporter> | undefined;
+
+beforeAll(() => {
+  fs.mkdirSync(TEMP_DIR, { recursive: true });
+});
+
+afterAll(() => {
+  // Best-effort cleanup; ignore failures (e.g., concurrent runs).
+  try {
+    fs.rmSync(TEMP_DIR, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+beforeEach(() => {
+  priorReporter = Try.getDefaultReporter();
+  Try.setDefaultReporter(new NoopReporter());
+});
+
+afterEach(() => {
+  if (priorReporter) Try.setDefaultReporter(priorReporter);
+});
+
+for (const file of files) {
+  if (file.blocks.length === 0) continue;
+
+  describe(`${file.relPath} doctest`, () => {
+    it.each(file.blocks.map((b) => [b.startLine, b] as const))(
+      'line %i',
+      async (_startLine, block) => {
+        const tmpFile = path.join(TEMP_DIR, `${randomUUID()}.ts`);
+        fs.writeFileSync(tmpFile, block.code, 'utf8');
+        try {
+          await import(/* @vite-ignore */ tmpFile);
+        } catch (err) {
+          const origin = `${file.relPath}:${block.startLine}`;
+          const base = err instanceof Error ? err : new Error(String(err));
+          const wrapped = new Error(
+            `doctest snippet failed at ${origin}\n${base.message}`,
+          );
+          wrapped.cause = base;
+          wrapped.stack = base.stack;
+          throw wrapped;
+        } finally {
+          try {
+            fs.unlinkSync(tmpFile);
+          } catch {
+            /* ignore */
+          }
+        }
+      },
+    );
+  });
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,32 @@
+import path from 'node:path';
 import { defineConfig } from 'vitest/config';
 
+// vitest aliases map the package's public entry points to local
+// `src/` so README / docs snippets can import from `@power-rent/try-catch[/sub]`
+// and still execute against real source during the doctest harness.
+// Order matters — sub-path aliases must be matched before the bare package
+// alias, so we use an ordered array (not an object).
 export default defineConfig({
+  resolve: {
+    alias: [
+      {
+        find: '@power-rent/try-catch/node',
+        replacement: path.resolve(__dirname, 'src/node/index.ts'),
+      },
+      {
+        find: '@power-rent/try-catch/browser',
+        replacement: path.resolve(__dirname, 'src/browser/index.ts'),
+      },
+      {
+        find: '@power-rent/try-catch/nextjs',
+        replacement: path.resolve(__dirname, 'src/nextjs/index.ts'),
+      },
+      {
+        find: '@power-rent/try-catch',
+        replacement: path.resolve(__dirname, 'src/index.ts'),
+      },
+    ],
+  },
   test: {
     environment: 'node',
     globals: true,


### PR DESCRIPTION
Rewritten README/docs/examples for the type-safe surface and uniform `.report()` semantics. A doctest harness executes tagged snippets from README and `docs/*.md` against the real API in CI.

Stacked on #50. Merge core first. Part of the #36 split (3/3).